### PR TITLE
ostreeuploader: param to specify backend API version

### DIFF
--- a/cmd/fiocheck/main.go
+++ b/cmd/fiocheck/main.go
@@ -21,13 +21,14 @@ func main() {
 	ostreeHubUrl := flag.String("server", DefaultServerUrl, "An URL to OSTree Hub a repo is hosted in")
 	factory := flag.String("factory", "", "A Factory to a repo belongs to")
 	creds := flag.String("creds", "", "A credential archive with auth material")
+	apiVer := flag.String("api-version", "v1", "A version of the OSTree Hub API to communicate with")
 	flag.Parse()
 
 	var checker ostreeuploader.Checker
 	if *creds != "" {
-		checker, err = ostreeuploader.NewChecker(*repo, *creds)
+		checker, err = ostreeuploader.NewChecker(*repo, *creds, *apiVer)
 	} else {
-		checker, err = ostreeuploader.NewCheckerNoAuth(*repo, *ostreeHubUrl, *factory)
+		checker, err = ostreeuploader.NewCheckerNoAuth(*repo, *ostreeHubUrl, *factory, *apiVer)
 	}
 	if err != nil {
 		log.Fatalf("Failed to create Fio Pusher: %s\n", err.Error())

--- a/cmd/fiopush/main.go
+++ b/cmd/fiopush/main.go
@@ -22,13 +22,14 @@ func main() {
 	factory := flag.String("factory", "", "A Factory to upload repo for")
 	creds := flag.String("creds", "", "A credential archive with auth material")
 	summary := flag.Bool("summary", false, "A flag to turn on a summary update at the end of repo push")
+	apiVer := flag.String("api-version", "v1", "A version of the OSTree Hub API to communicate with")
 	flag.Parse()
 
 	var pusher ostreeuploader.Pusher
 	if *creds != "" {
-		pusher, err = ostreeuploader.NewPusher(*repo, *creds)
+		pusher, err = ostreeuploader.NewPusher(*repo, *creds, *apiVer)
 	} else {
-		pusher, err = ostreeuploader.NewPusherNoAuth(*repo, *ostreeHubUrl, *factory)
+		pusher, err = ostreeuploader.NewPusherNoAuth(*repo, *ostreeHubUrl, *factory, *apiVer)
 	}
 	if err != nil {
 		log.Fatalf("Failed to create Fio Pusher: %s\n", err.Error())

--- a/pkg/ostreeuploader/check.go
+++ b/pkg/ostreeuploader/check.go
@@ -34,16 +34,16 @@ var (
 	}
 )
 
-func NewChecker(repo string, credFile string) (Checker, error) {
-	th, err := newOSTreeHubAccessor(repo, credFile)
+func NewChecker(repo string, credFile string, apiVer string) (Checker, error) {
+	th, err := newOSTreeHubAccessor(repo, credFile, apiVer)
 	if err != nil {
 		return nil, err
 	}
 	return &checker{ostreehub: th}, nil
 }
 
-func NewCheckerNoAuth(repo string, hubURL string, factory string) (Checker, error) {
-	th, err := newOSTreeHubAccessorNoAuth(repo, hubURL, factory)
+func NewCheckerNoAuth(repo string, hubURL string, factory string, apiVer string) (Checker, error) {
+	th, err := newOSTreeHubAccessorNoAuth(repo, hubURL, factory, apiVer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ostreeuploader/push.go
+++ b/pkg/ostreeuploader/push.go
@@ -98,7 +98,7 @@ var (
 	}
 )
 
-func newOSTreeHubAccessor(repo string, credFile string) (*ostreeHubAccessor, error) {
+func newOSTreeHubAccessor(repo string, credFile string, apiVer string) (*ostreeHubAccessor, error) {
 	if err := checkRepoDir(repo); err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func newOSTreeHubAccessor(repo string, credFile string) (*ostreeHubAccessor, err
 	if err != nil {
 		return nil, err
 	}
-	reqUrl, err := url.Parse(hub.URL + "/ota/ostreehub/" + hub.Factory + "/v1/repos/lmp")
+	reqUrl, err := url.Parse(hub.URL + "/ota/ostreehub/" + hub.Factory + "/" + apiVer + "/repos/lmp")
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +114,7 @@ func newOSTreeHubAccessor(repo string, credFile string) (*ostreeHubAccessor, err
 	return &ostreeHubAccessor{repo: repo, url: reqUrl, hub: hub, token: ""}, nil
 }
 
-func newOSTreeHubAccessorNoAuth(repo string, hubURL string, factory string) (*ostreeHubAccessor, error) {
+func newOSTreeHubAccessorNoAuth(repo string, hubURL string, factory string, apiVer string) (*ostreeHubAccessor, error) {
 	if err := checkRepoDir(repo); err != nil {
 		return nil, err
 	}
@@ -128,23 +128,23 @@ func newOSTreeHubAccessorNoAuth(repo string, hubURL string, factory string) (*os
 		URL:     hubURL,
 		Factory: factory,
 	}
-	reqUrl, err := url.Parse(hub.URL + "/v1/repos/lmp?factory=" + hub.Factory)
+	reqUrl, err := url.Parse(hub.URL + "/" + apiVer + "/repos/lmp?factory=" + hub.Factory)
 	if err != nil {
 		return nil, err
 	}
 	return &ostreeHubAccessor{repo: repo, url: reqUrl, hub: &hub, token: ""}, nil
 }
 
-func NewPusher(repo string, credFile string) (Pusher, error) {
-	th, err := newOSTreeHubAccessor(repo, credFile)
+func NewPusher(repo string, credFile string, apiVer string) (Pusher, error) {
+	th, err := newOSTreeHubAccessor(repo, credFile, apiVer)
 	if err != nil {
 		return nil, err
 	}
 	return &pusher{ostreehub: th}, nil
 }
 
-func NewPusherNoAuth(repo string, hubURL string, factory string) (Pusher, error) {
-	th, err := newOSTreeHubAccessorNoAuth(repo, hubURL, factory)
+func NewPusherNoAuth(repo string, hubURL string, factory string, apiVer string) (Pusher, error) {
+	th, err := newOSTreeHubAccessorNoAuth(repo, hubURL, factory, apiVer)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add param to specify a version of the backend API to communicate to.
It will help to "eat own dog food" and facilitate smooth transition
from the regional bucket to many multi-region buckets.

Signed-off-by: Mike Sul <mike.sul@foundries.io>