### PR TITLE
ostreeuploader: upload a repo config to storage

### DIFF
--- a/pkg/ostreeuploader/check.go
+++ b/pkg/ostreeuploader/check.go
@@ -31,6 +31,7 @@ type (
 var (
 	checkFileFilterIn = []string{
 		"./objects/",
+		"./config",
 	}
 )
 


### PR DESCRIPTION
In order to pull an ostree repo directly from GCS the source repo must
include its config file on the storage. Thus, the upload client and
ostreehub should allow the config file upload.

Signed-off-by: Mike Sul <mike.sul@foundries.io>