### PR TITLE
Pass URL to ostreeuploader module for token authentication

### DIFF
--- a/cmd/fiocheck/main.go
+++ b/cmd/fiocheck/main.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"flag"
-	"github.com/foundriesio/ostreeuploader/pkg/ostreeuploader"
 	"log"
 	"os"
+
+	"github.com/foundriesio/ostreeuploader/pkg/ostreeuploader"
 )
 
 var (
@@ -28,7 +29,7 @@ func main() {
 
 	var checker ostreeuploader.Checker
 	if len(*token) > 0 && len(*factory) > 0 {
-		checker, err = ostreeuploader.NewCheckerWithToken(*repo, *factory, *token, *apiVer)
+		checker, err = ostreeuploader.NewCheckerWithToken(*repo, *ostreeHubUrl, *factory, *token, *apiVer)
 	} else if *creds != "" {
 		checker, err = ostreeuploader.NewChecker(*repo, *creds, *apiVer)
 	} else {

--- a/cmd/fiopush/main.go
+++ b/cmd/fiopush/main.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"flag"
-	"github.com/foundriesio/ostreeuploader/pkg/ostreeuploader"
 	"log"
 	"os"
+
+	"github.com/foundriesio/ostreeuploader/pkg/ostreeuploader"
 )
 
 var (
@@ -29,7 +30,7 @@ func main() {
 
 	var pusher ostreeuploader.Pusher
 	if len(*token) > 0 && len(*factory) > 0 {
-		pusher, err = ostreeuploader.NewPusherWithToken(*repo, *factory, *token, *apiVer)
+		pusher, err = ostreeuploader.NewPusherWithToken(*repo, *ostreeHubUrl, *factory, *token, *apiVer)
 	} else if *creds != "" {
 		pusher, err = ostreeuploader.NewPusher(*repo, *creds, *apiVer)
 	} else {

--- a/cmd/fiosync/main.go
+++ b/cmd/fiosync/main.go
@@ -3,9 +3,10 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/foundriesio/ostreeuploader/pkg/ostreeuploader"
 	"log"
 	"os"
+
+	"github.com/foundriesio/ostreeuploader/pkg/ostreeuploader"
 )
 
 var (
@@ -47,7 +48,7 @@ func main() {
 	apiVer := "v2"
 	var puller ostreeuploader.Puller
 	if len(*token) > 0 && len(*srcFactory) > 0 {
-		puller, err = ostreeuploader.NewPullerWithToken(repoDir, *srcFactory, *token, apiVer)
+		puller, err = ostreeuploader.NewPullerWithToken(repoDir, *ostreeHubUrl, *srcFactory, *token, apiVer)
 	} else if *srcCreds != "" {
 		puller, err = ostreeuploader.NewPuller(repoDir, *srcCreds, apiVer)
 	} else {
@@ -59,7 +60,7 @@ func main() {
 
 	var pusher ostreeuploader.Pusher
 	if len(*token) > 0 && len(*srcFactory) > 0 {
-		pusher, err = ostreeuploader.NewPusherWithToken(repoDir, *dstFactory, *token, apiVer)
+		pusher, err = ostreeuploader.NewPusherWithToken(repoDir, *ostreeHubUrl, *dstFactory, *token, apiVer)
 	} else if *dstCreds != "" {
 		pusher, err = ostreeuploader.NewPusher(repoDir, *dstCreds, apiVer)
 	} else {

--- a/pkg/ostreeuploader/check.go
+++ b/pkg/ostreeuploader/check.go
@@ -41,8 +41,8 @@ var (
 	}
 )
 
-func NewCheckerWithToken(repo string, factory string, token string, apiVer string) (Checker, error) {
-	th, err := newOSTreeHubAccessorWithToken(repo, factory, token, apiVer)
+func NewCheckerWithToken(repo, hubURL, factory, token, apiVer string) (Checker, error) {
+	th, err := newOSTreeHubAccessorWithToken(repo, hubURL, factory, token, apiVer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ostreeuploader/pull.go
+++ b/pkg/ostreeuploader/pull.go
@@ -22,13 +22,13 @@ type (
 	}
 )
 
-func NewPullerWithToken(repo string, factory string, token string, apiVer string) (Puller, error) {
+func NewPullerWithToken(repo, hubURL, factory, token, apiVer string) (Puller, error) {
 	cmd := exec.Command("ostree", "init", "--repo", repo, "--mode", "archive")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("err: %s", out)
 	}
-	th, err := newOSTreeHubAccessorWithToken(repo, factory, token, apiVer)
+	th, err := newOSTreeHubAccessorWithToken(repo, hubURL, factory, token, apiVer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ostreeuploader/push.go
+++ b/pkg/ostreeuploader/push.go
@@ -20,10 +20,6 @@ import (
 	"time"
 )
 
-const (
-	FioApiBaseUrl = "https://api.foundries.io"
-)
-
 type (
 	SendReport struct {
 		FileNumb uint
@@ -120,19 +116,23 @@ func (t FioToken) SetAuthHeader(req *http.Request) {
 	req.Header.Set("osf-token", string(t))
 }
 
-func newOSTreeHubAccessorWithToken(repo string, factory string, token string, apiVer string) (*ostreeHubAccessor, error) {
+func newOSTreeHubAccessorWithToken(repo, hubURL, factory, token, apiVer string) (*ostreeHubAccessor, error) {
 	if err := checkRepoDir(repo); err != nil {
 		return nil, err
 	}
+	if hubURL[len(hubURL)-1] != '/' {
+		hubURL += "/"
+	}
 	hub := &OSTreeHub{
-		URL:     FioApiBaseUrl,
+		URL:     hubURL,
 		Factory: factory,
 		Auth:    nil,
 	}
-	reqUrl, err := url.Parse(hub.URL + "/ota/ostreehub/" + factory + "/" + apiVer + "/repos/lmp")
+	reqUrl, err := url.Parse(hub.URL + factory + "/" + apiVer + "/repos/lmp")
 	if err != nil {
 		return nil, err
 	}
+
 	return &ostreeHubAccessor{repo: repo, url: reqUrl, hub: hub, token: FioToken(token)}, nil
 }
 
@@ -173,8 +173,8 @@ func newOSTreeHubAccessorNoAuth(repo string, hubURL string, factory string, apiV
 	return &ostreeHubAccessor{repo: repo, url: reqUrl, hub: &hub, token: OAuth2Token("")}, nil
 }
 
-func NewPusherWithToken(repo string, factory string, token string, apiVer string) (Pusher, error) {
-	th, err := newOSTreeHubAccessorWithToken(repo, factory, token, apiVer)
+func NewPusherWithToken(repo, hubURL, factory, token, apiVer string) (Pusher, error) {
+	th, err := newOSTreeHubAccessorWithToken(repo, hubURL, factory, token, apiVer)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The token authentication works well but is tied to api.fio. This change allows is to use the `-server` option the user was already able to set from the CLI.

While changing these files my editor also re-organized the imports in a more standard format.