### PR TITLE
Band aid to stream ostree repo objects through CF proxy

### DIFF
--- a/pkg/ostreeuploader/push.go
+++ b/pkg/ostreeuploader/push.go
@@ -92,7 +92,7 @@ const (
 	// a number of goroutine to read from the file queue and push them to OSTreeHub
 	// each goroutine at first checks if given files are already present on GCS and uploads
 	// only those files/objects that are missing or CRC is not equal
-	concurrentPusherNumb int = 10
+	concurrentPusherNumb int = 3
 	// maximum number of files to check and push per a single HTTP request
 	filesToCheckAndPushMaxNumb int = 100
 	// maximum file size

--- a/pkg/ostreeuploader/push.go
+++ b/pkg/ostreeuploader/push.go
@@ -530,7 +530,7 @@ func pushRepo(pr *io.PipeReader, u *url.URL, token Token, corId string) <-chan *
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 		DisableCompression:    false,
-		WriteBufferSize:       1024 * 1025 * 10,
+		WriteBufferSize:       1024 * 1024 * 10,
 		ReadBufferSize:        1024 * 1024 * 10,
 	}
 


### PR DESCRIPTION
-  Decouple the check and push parameters.
- Decrease a number of gouroutines and files to check per request for the push process.