### PR TITLE
Add fiopull

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ bd = bin
 push_exe = fiopush
 check_exe = fiocheck
 sync_exe = fiosync
+pull_exe = fiopull
 linter := $(shell which golangci-lint 2>/dev/null || echo $(HOME)/go/bin/golangci-lint)
 
 all: $(push_exe) $(check_exe) $(sync_exe)
@@ -21,6 +22,13 @@ $(check_exe): $(bd) cmd/fiocheck/main.go
 
 $(sync_exe): $(bd) cmd/fiosync/main.go
 	$(GO) build $(GOBUILDFLAGS) -o $(bd)/$@ cmd/fiosync/main.go
+
+# fiopull is a pure-Go ostree client (no libostree, no `ostree` binary). It is
+# Linux-only (//go:build linux), so it is not part of the default `all` target;
+# build it explicitly with `make fiopull` on a Linux host or with GOOS=linux.
+$(pull_exe): $(bd)
+	CGO_ENABLED=0 $(GO) build $(GOBUILDFLAGS) -o $(bd)/$@ ./cmd/fiopull
+
 
 clean:
 	@rm -r $(bd)

--- a/README.md
+++ b/README.md
@@ -67,11 +67,25 @@ Exit codes: `0` ok, `1` error, `2` usage, `3` insufficient storage, `4` size
 unavailable.
 
 The `ostree.sizes` metadata path only works if the factory's ostree commits were
-built with `ostree commit --generate-sizes`. For LmP-based factories this is
-controlled by the OSTree commit step of the image build in your
-`meta-subscriber-overrides` layer (or your own Yocto CI); enable it there so the
-commits your factory publishes carry the sizes table. Without it (and without a
-published static delta) `update-size` cannot estimate a size and exits 4.
+built with `ostree commit --generate-sizes`. For LmP-based factories the flags
+passed to `ostree commit` come from the `EXTRA_OSTREE_COMMIT` variable in
+meta-updater's `image_types_ostree.bbclass`, so enable it by appending
+`--generate-sizes` to that variable from your `meta-subscriber-overrides` layer
+(the layer intended for factory customization).
+
+For example, add a file such as
+`meta-subscriber-overrides/recipes-samples/images/lmp-factory-image.bbappend`
+(or your image recipe's `.bbappend`) containing:
+
+```
+EXTRA_OSTREE_COMMIT:append = " --generate-sizes"
+```
+
+The leading space matters — `EXTRA_OSTREE_COMMIT` is inserted verbatim as the
+final argument of the `ostree commit` invocation. After a factory image build,
+the commits your factory publishes will carry the `ostree.sizes` table. To turn
+it off again, drop the `.bbappend`. Without it (and without a published static
+delta) `update-size` cannot estimate a size and exits 4.
 
 ##### pull
 Pulls a commit (and every object it references) into a local bare-user repo. The
@@ -79,10 +93,14 @@ pull is delta-aware and resumable: pass `--from` to use the from→target static
 delta when the remote publishes one (falling back to a full object pull), and
 re-running resumes an interrupted pull.
 ```
-./bin/fiopull pull [--from <CSUM>] [--no-delta] [--jobs <N>] --repo <local-repo> <URL> <COMMIT | REF>
+./bin/fiopull pull [--from <CSUM>] [--no-delta] [--jobs <N>] [--progress auto|log|none] --repo <local-repo> <URL> <COMMIT | REF>
 ```
 `URL` and the target `COMMIT` (a 64-char hex checksum) or `REF` (e.g. `main`,
 resolved against the remote) are mandatory positional arguments and must come
 after any flags. `--no-delta` forces a full object pull; `--jobs` bounds
-concurrent content downloads.
+concurrent content downloads. `--progress` selects progress reporting: `auto`
+(default) draws a live bar when stderr is a terminal and is otherwise silent;
+`log` emits periodic newline-terminated lines to stderr (no carriage returns),
+for a non-interactive parent such as aktualizr-lite that captures the output;
+`none` disables it.
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 # OSTreeUploader
-Tools to upload an ostree repo to the Foundries backend
+Tools to upload an ostree repo to the Foundries backend, and a pure-Go ostree
+client (`fiopull`) to pull commits and estimate an update's size.
 
 ## Usage
 
 ### Build
 
 ```make```
+
+This builds `fiopush`, `fiocheck` and `fiosync`. `fiopull` is Linux-only and is
+not part of the default target; build it separately:
+
+```make fiopull```
 
 ### Run
 
@@ -29,3 +35,54 @@ The `ostree` command line utility must be installed on a host system.
 ```
 If `-repo-dir` is not specified then a temporal directory will be created before the pull process and then removed once a repo is fully synced.
 If `-repo-dir` is specified then the repo directory is not removed after the sync process completion.
+
+#### Pull
+`fiopull` is a pure-Go ostree client (no libostree, no `ostree` binary). It is
+Linux-only and designed to be shelled out to by other tools (e.g.
+aktualizr-lite), so it offers a machine-readable `--format json` mode. It has
+two subcommands.
+
+`--url` may be an `http(s)://` or `file://` base URL of an ostree repo — for
+example a signed object-store (GCS) URL that a caller such as aktualizr-lite
+obtained from the Device Gateway. `fiopull` is Device-Gateway-agnostic: it does
+not talk to the gateway or handle mTLS/PKCS#11 itself. Pass any auth via the URL
+itself (a signed URL) or via repeatable `--header 'Key: Value'` (e.g.
+`--header 'Authorization: Bearer <token>'`).
+
+##### update-size
+Estimates the storage an update needs, without downloading object bodies. It
+picks the cheapest accurate source automatically: the `--from`→target static
+delta superblock if one is published, else the target commit's `ostree.sizes`
+metadata (present when the commit was built with `ostree commit
+--generate-sizes`). Both are a single fetch.
+```
+./bin/fiopull update-size --url <URL> (--ref <REF> | --commit <CSUM>) [--from <CSUM>] [--repo <local-repo>] [--format text|json]
+```
+`--from` enables the static-delta fast path. `--repo` points at a local
+bare-user repo whose already-present objects are subtracted from the estimate.
+When neither a static delta nor `ostree.sizes` is available the size cannot be
+determined and the command exits 4.
+
+Exit codes: `0` ok, `1` error, `2` usage, `3` insufficient storage, `4` size
+unavailable.
+
+The `ostree.sizes` metadata path only works if the factory's ostree commits were
+built with `ostree commit --generate-sizes`. For LmP-based factories this is
+controlled by the OSTree commit step of the image build in your
+`meta-subscriber-overrides` layer (or your own Yocto CI); enable it there so the
+commits your factory publishes carry the sizes table. Without it (and without a
+published static delta) `update-size` cannot estimate a size and exits 4.
+
+##### pull
+Pulls a commit (and every object it references) into a local bare-user repo. The
+pull is delta-aware and resumable: pass `--from` to use the from→target static
+delta when the remote publishes one (falling back to a full object pull), and
+re-running resumes an interrupted pull.
+```
+./bin/fiopull pull [--from <CSUM>] [--no-delta] [--jobs <N>] --repo <local-repo> <URL> <COMMIT | REF>
+```
+`URL` and the target `COMMIT` (a 64-char hex checksum) or `REF` (e.g. `main`,
+resolved against the remote) are mandatory positional arguments and must come
+after any flags. `--no-delta` forces a full object pull; `--jobs` bounds
+concurrent content downloads.
+

--- a/cmd/fiopull/main.go
+++ b/cmd/fiopull/main.go
@@ -155,6 +155,7 @@ func cmdPull(args []string) int {
 	from := fs.String("from", "", "current/base commit; enables the static-delta fast path")
 	noDelta := fs.Bool("no-delta", false, "force a full object pull (disable static deltas)")
 	jobs := fs.Int("jobs", 4, "concurrent content downloads")
+	progress := fs.String("progress", "auto", "progress reporting: auto (TTY bar, else silent), log (periodic lines to stderr, for non-interactive callers), none")
 	headers := headerFlags{}
 	fs.Var(headers, "header", "extra request header 'Key: Value' (repeatable)")
 	_ = fs.Parse(args)
@@ -184,16 +185,30 @@ func cmdPull(args []string) int {
 		NoDelta:     *noDelta,
 		Concurrency: *jobs,
 	}
-	// Render a progress bar only when stderr is a terminal; stay silent (summary
-	// only) otherwise, so machine callers and CI logs are not polluted with \r.
-	tty := isatty.IsTerminal(os.Stderr.Fd())
-	if tty {
-		opts.Progress = newTTYProgress()
+	// Select a progress reporter. "auto" renders a \r bar only when stderr is a
+	// terminal and is otherwise silent (so machine callers and CI logs are not
+	// polluted with \r); "log" emits periodic newline-terminated lines suitable
+	// for a non-interactive parent that captures stderr line by line (e.g.
+	// aktualizr-lite); "none" disables reporting.
+	var finish func()
+	switch *progress {
+	case "auto":
+		if isatty.IsTerminal(os.Stderr.Fd()) {
+			opts.Progress = newTTYProgress()
+			finish = finishTTYProgress
+		}
+	case "log":
+		opts.Progress = newLogProgress()
+	case "none":
+		// no reporting
+	default:
+		fmt.Fprintf(os.Stderr, "invalid --progress %q (want auto|log|none)\n", *progress)
+		return 2
 	}
 
 	res, err := ostree.OpenRepo(*repo).Pull(context.Background(), opts)
-	if tty {
-		finishTTYProgress()
+	if finish != nil {
+		finish()
 	}
 	if err != nil {
 		if errors.Is(err, ostree.ErrInsufficientStorage) {

--- a/cmd/fiopull/main.go
+++ b/cmd/fiopull/main.go
@@ -26,6 +26,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/mattn/go-isatty"
+
 	"github.com/foundriesio/ostreeuploader/pkg/ostree"
 )
 
@@ -174,14 +176,25 @@ func cmdPull(args []string) int {
 
 	rc := ostree.RemoteConfig{BaseURL: rurl, Headers: headers}
 
-	res, err := ostree.OpenRepo(*repo).Pull(context.Background(), ostree.PullOptions{
+	opts := ostree.PullOptions{
 		Remote:      rc,
 		Ref:         ref,
 		Commit:      commit,
 		From:        *from,
 		NoDelta:     *noDelta,
 		Concurrency: *jobs,
-	})
+	}
+	// Render a progress bar only when stderr is a terminal; stay silent (summary
+	// only) otherwise, so machine callers and CI logs are not polluted with \r.
+	tty := isatty.IsTerminal(os.Stderr.Fd())
+	if tty {
+		opts.Progress = newTTYProgress()
+	}
+
+	res, err := ostree.OpenRepo(*repo).Pull(context.Background(), opts)
+	if tty {
+		finishTTYProgress()
+	}
 	if err != nil {
 		if errors.Is(err, ostree.ErrInsufficientStorage) {
 			fmt.Fprintln(os.Stderr, "INSUFFICIENT STORAGE:", err)

--- a/cmd/fiopull/main.go
+++ b/cmd/fiopull/main.go
@@ -1,0 +1,231 @@
+//go:build linux
+
+// Command fiopull is a small CLI over the ostree package: a pure-Go ostree
+// client (no libostree, no `ostree` binary). It is designed to be shelled out to
+// by other tools (e.g. aktualizr-lite), hence the machine-readable `--format
+// json` mode.
+//
+// fiopull is Device-Gateway-agnostic: it fetches ostree data from a plain
+// HTTP(s) server (typically a signed object-store / GCS URL that the caller
+// obtained from the gateway) or a local file:// repo. It does not speak the
+// gateway download-urls protocol and has no mTLS/PKCS#11 handling; any auth is
+// carried by the URL itself or via repeatable --header options. Subcommands:
+//
+//	update-size — the update's download/on-disk size, choosing the cheapest
+//	              accurate source (static delta, else commit ostree.sizes
+//	              metadata).
+//	pull        — pull a commit (delta-aware, resumable) into a local repo.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/foundriesio/ostreeuploader/pkg/ostree"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(2)
+	}
+	switch os.Args[1] {
+	case "update-size":
+		os.Exit(cmdUpdateSize(os.Args[2:]))
+	case "pull":
+		os.Exit(cmdPull(os.Args[2:]))
+	default:
+		usage()
+		os.Exit(2)
+	}
+}
+
+func usage() {
+	fmt.Fprintln(os.Stderr, `usage:
+  fiopull update-size --url URL (--ref REF | --commit CSUM) [--from CSUM]
+                      [--header 'K: V' ...] [--format text|json]
+  fiopull pull        [--from CSUM] [--no-delta] [--jobs N] [--header 'K: V' ...]
+                      --repo PATH URL (COMMIT | REF)
+
+URL may be an http(s):// or file:// base URL of an ostree repo (e.g. a signed
+object-store URL obtained from the Device Gateway). fiopull does not talk to the
+gateway itself; pass any auth via the URL or --header 'Authorization: Bearer ...'.
+
+For "pull", URL and COMMIT-or-REF are mandatory positional arguments and must
+come after any flags. A 64-char hex argument is treated as a commit checksum,
+otherwise as a ref to resolve (e.g. main).
+
+update-size picks the cheapest accurate source automatically: static delta if
+one is published for --from->target, else the commit's ostree.sizes metadata.
+Both are a single fetch. When neither is available it exits 4 so a caller can
+decide what to do.
+Exit codes: 0 ok, 1 error, 2 usage, 3 insufficient storage, 4 size unavailable.`)
+}
+
+func cmdUpdateSize(args []string) int {
+	fs := flag.NewFlagSet("update-size", flag.ExitOnError)
+	rurl := fs.String("url", "", "remote base URL (http(s):// or file://)")
+	from := fs.String("from", "", "current/base commit; enables the static-delta fast path")
+	ref := fs.String("ref", "", "ref to size (e.g. main)")
+	commit := fs.String("commit", "", "explicit target commit checksum to size")
+	repo := fs.String("repo", "", "path to local bare-user ostree repo; objects already present are excluded from the size")
+	format := fs.String("format", "text", "output format: text|json")
+	headers := headerFlags{}
+	fs.Var(headers, "header", "extra request header 'Key: Value' (repeatable)")
+	_ = fs.Parse(args)
+
+	if *rurl == "" || (*ref == "" && *commit == "") {
+		usage()
+		return 2
+	}
+
+	rc := ostree.RemoteConfig{BaseURL: *rurl, Headers: headers}
+
+	var localRepo *ostree.Repo
+	if *repo != "" {
+		localRepo = ostree.OpenRepo(*repo)
+	}
+
+	ctx := context.Background()
+	to := *commit
+	if to == "" {
+		var err error
+		if to, err = ostree.ResolveRemoteRef(ctx, rc, *ref); err != nil {
+			return fail(*format, err)
+		}
+	}
+
+	us, err := ostree.RemoteUpdateSize(ctx, rc, *from, to, localRepo)
+	if err != nil {
+		if errors.Is(err, ostree.ErrSizeUnavailable) {
+			// No efficient estimate available (no static delta, no ostree.sizes).
+			// Distinct exit code so a caller can proceed without a size rather
+			// than treat this as a hard failure.
+			if *format == "json" {
+				emitJSON(map[string]string{"error": err.Error(), "method": "unavailable"})
+			} else {
+				fmt.Fprintln(os.Stderr, "size unavailable:", err)
+			}
+			return 4
+		}
+		return fail(*format, err)
+	}
+	if *format == "json" {
+		emitJSON(us)
+	} else {
+		fmt.Printf("Commit: %s\n", to)
+		fmt.Printf("Download Size: %d (%s)\n", us.Compressed, ostree.FormatBytes(us.Compressed))
+		if us.Uncompressed > 0 {
+			fmt.Printf("Uncompressed Size: %d (%s)\n", us.Uncompressed, ostree.FormatBytes(us.Uncompressed))
+		}
+		fmt.Printf("Method: %s\n", us.Method)
+	}
+	return 0
+}
+
+// headerFlags collects repeatable --header 'K: V' options.
+type headerFlags map[string]string
+
+func (h headerFlags) String() string { return "" }
+
+func (h headerFlags) Set(v string) error {
+	i := strings.IndexByte(v, ':')
+	if i < 0 {
+		return fmt.Errorf("header must be 'Key: Value', got %q", v)
+	}
+	key := strings.TrimSpace(v[:i])
+	val := strings.TrimSpace(v[i+1:])
+	if key == "" {
+		return fmt.Errorf("empty header key in %q", v)
+	}
+	h[key] = val
+	return nil
+}
+
+func cmdPull(args []string) int {
+	fs := flag.NewFlagSet("pull", flag.ExitOnError)
+	repo := fs.String("repo", "", "path to local bare-user ostree repo (created if absent)")
+	from := fs.String("from", "", "current/base commit; enables the static-delta fast path")
+	noDelta := fs.Bool("no-delta", false, "force a full object pull (disable static deltas)")
+	jobs := fs.Int("jobs", 4, "concurrent content downloads")
+	headers := headerFlags{}
+	fs.Var(headers, "header", "extra request header 'Key: Value' (repeatable)")
+	_ = fs.Parse(args)
+
+	// URL and the commit/ref are mandatory positional arguments (flags, if any,
+	// must precede them). The second positional is treated as a commit checksum
+	// when it looks like one, otherwise as a ref to resolve.
+	if fs.NArg() != 2 || *repo == "" {
+		usage()
+		return 2
+	}
+	rurl := fs.Arg(0)
+	commit, ref := "", ""
+	if looksLikeCommit(fs.Arg(1)) {
+		commit = fs.Arg(1)
+	} else {
+		ref = fs.Arg(1)
+	}
+
+	rc := ostree.RemoteConfig{BaseURL: rurl, Headers: headers}
+
+	res, err := ostree.OpenRepo(*repo).Pull(context.Background(), ostree.PullOptions{
+		Remote:      rc,
+		Ref:         ref,
+		Commit:      commit,
+		From:        *from,
+		NoDelta:     *noDelta,
+		Concurrency: *jobs,
+	})
+	if err != nil {
+		if errors.Is(err, ostree.ErrInsufficientStorage) {
+			fmt.Fprintln(os.Stderr, "INSUFFICIENT STORAGE:", err)
+			return 3
+		}
+		return fail("text", err)
+	}
+	mode := "full"
+	if res.UsedDelta {
+		mode = "delta"
+	}
+	fmt.Printf("pulled commit %s (%s)\n", res.Commit, mode)
+	fmt.Printf("  metadata fetched: %d\n", res.MetaFetched)
+	fmt.Printf("  content fetched:  %d\n", res.ContentFetched)
+	fmt.Printf("  skipped (resume): %d\n", res.ObjectsSkipped)
+	fmt.Printf("  bytes downloaded: %d (%s)\n", res.BytesDownloaded, ostree.FormatBytes(res.BytesDownloaded))
+	return 0
+}
+
+// looksLikeCommit reports whether s is a 64-char lowercase hex ostree commit
+// checksum. Anything else is treated as a ref name to resolve.
+func looksLikeCommit(s string) bool {
+	if len(s) != 64 {
+		return false
+	}
+	for _, c := range s {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func emitJSON(v any) {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(v)
+}
+
+func fail(format string, err error) int {
+	if format == "json" {
+		emitJSON(map[string]string{"error": err.Error()})
+	} else {
+		fmt.Fprintln(os.Stderr, "error:", err)
+	}
+	return 1
+}

--- a/cmd/fiopull/progress.go
+++ b/cmd/fiopull/progress.go
@@ -5,6 +5,8 @@ package main
 import (
 	"fmt"
 	"os"
+	"sync"
+	"time"
 
 	"github.com/foundriesio/ostreeuploader/pkg/ostree"
 )
@@ -44,4 +46,43 @@ func newTTYProgress() ostree.ProgressFunc {
 // finishTTYProgress closes the progress line so subsequent output starts fresh.
 func finishTTYProgress() {
 	fmt.Fprintln(os.Stderr)
+}
+
+// newLogProgress returns a ProgressFunc that writes periodic, newline-terminated
+// progress lines to stderr, for a non-interactive parent (e.g. aktualizr-lite)
+// that captures the child's output line by line. Unlike the TTY bar it emits no
+// \r, so it is safe to log. Output is throttled to at most one line per second,
+// but a phase change or the final done==total snapshot always prints, so the
+// last line for each phase reports completion. The callback may be invoked
+// concurrently, so emission is serialized under a mutex.
+func newLogProgress() ostree.ProgressFunc {
+	const minInterval = time.Second
+	var (
+		mu        sync.Mutex
+		lastAt    time.Time
+		lastPhase ostree.PullPhase
+		started   bool
+	)
+	return func(p ostree.PullProgress) {
+		mu.Lock()
+		defer mu.Unlock()
+		now := time.Now()
+		done := p.ObjectsTotal > 0 && p.ObjectsDone >= p.ObjectsTotal
+		phaseChanged := !started || p.Phase != lastPhase
+		if !phaseChanged && !done && now.Sub(lastAt) < minInterval {
+			return
+		}
+		started = true
+		lastPhase = p.Phase
+		lastAt = now
+
+		if p.ObjectsTotal > 0 {
+			pct := p.ObjectsDone * 100 / p.ObjectsTotal
+			fmt.Fprintf(os.Stderr, "fiopull: %s %d/%d (%d%%) %s\n",
+				p.Phase, p.ObjectsDone, p.ObjectsTotal, pct, ostree.FormatBytes(p.BytesDownloaded))
+		} else {
+			fmt.Fprintf(os.Stderr, "fiopull: %s %d objects %s\n",
+				p.Phase, p.ObjectsDone, ostree.FormatBytes(p.BytesDownloaded))
+		}
+	}
 }

--- a/cmd/fiopull/progress.go
+++ b/cmd/fiopull/progress.go
@@ -1,0 +1,47 @@
+//go:build linux
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/foundriesio/ostreeuploader/pkg/ostree"
+)
+
+// newTTYProgress returns a ProgressFunc that renders a single-line, carriage
+// -return-updated progress bar to stderr. It is intended for interactive use
+// only; callers should install it solely when stderr is a terminal.
+func newTTYProgress() ostree.ProgressFunc {
+	const barWidth = 30
+	return func(p ostree.PullProgress) {
+		var bar string
+		if p.ObjectsTotal > 0 {
+			frac := float64(p.ObjectsDone) / float64(p.ObjectsTotal)
+			if frac > 1 {
+				frac = 1
+			}
+			filled := int(frac * float64(barWidth))
+			b := make([]byte, barWidth)
+			for i := range b {
+				if i < filled {
+					b[i] = '='
+				} else {
+					b[i] = ' '
+				}
+			}
+			bar = fmt.Sprintf("[%s] %d/%d", string(b), p.ObjectsDone, p.ObjectsTotal)
+		} else {
+			bar = fmt.Sprintf("%d objects", p.ObjectsDone)
+		}
+		// \r returns to the start of the line; trailing spaces clear any leftover
+		// characters from a longer previous line.
+		fmt.Fprintf(os.Stderr, "\rpulling %-8s %s  %s          ",
+			p.Phase, bar, ostree.FormatBytes(p.BytesDownloaded))
+	}
+}
+
+// finishTTYProgress closes the progress line so subsequent output starts fresh.
+func finishTTYProgress() {
+	fmt.Fprintln(os.Stderr)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/foundriesio/ostreeuploader
 
-go 1.15
+go 1.22
+
+require github.com/ulikunitz/xz v0.5.15

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,9 @@ module github.com/foundriesio/ostreeuploader
 
 go 1.22
 
-require github.com/ulikunitz/xz v0.5.15
+require (
+	github.com/mattn/go-isatty v0.0.20
+	github.com/ulikunitz/xz v0.5.15
+)
+
+require golang.org/x/sys v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
+github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,6 @@
+github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
+github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
 github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/gvariant/encode.go
+++ b/pkg/gvariant/encode.go
@@ -1,0 +1,195 @@
+package gvariant
+
+// This file implements the minimal slice of GVariant *serialization* that
+// fiopull needs in order to write bare-user content objects: the two file
+// header GVariants ostree computes checksums and xattrs from. It is not a
+// general encoder; it exposes just the two concrete shapes, built on small
+// generic tuple/array serializers that follow the same framing rules as the
+// decoder in type.go (GLib gvariant-serialiser.c).
+//
+// IMPORTANT endianness note: ostree stores uid/gid/mode/rdev in these headers
+// in big-endian (libostree passes GUINT32_TO_BE(...) into g_variant_new), which
+// is the opposite of GVariant's normal little-endian integer encoding. The
+// encoders below therefore emit those specific uint32 fields big-endian, to
+// match the on-disk bytes (verified against libostree 2024.5 output).
+
+// Xattr is a single extended attribute: a NUL-terminated name and a raw value,
+// matching ostree's a(ayay) xattr representation (the name's trailing NUL is
+// included in Name's bytes by the caller via EncodeFile*; see below).
+type Xattr struct {
+	Name  []byte // attribute name, WITHOUT trailing NUL (added during encoding)
+	Value []byte
+}
+
+// EncodeFileHeader serializes the uncompressed ostree file header GVariant
+// "(uuuusa(ayay))" = (uid, gid, mode, rdev, symlinkTarget, xattrs). rdev is
+// always 0. This is the buffer ostree length-prefixes and hashes to derive a
+// content object's checksum.
+func EncodeFileHeader(uid, gid, mode uint32, symlinkTarget string, xattrs []Xattr) []byte {
+	members := []member{
+		{data: beU32(uid), align: 4, fixed: true},
+		{data: beU32(gid), align: 4, fixed: true},
+		{data: beU32(mode), align: 4, fixed: true},
+		{data: beU32(0), align: 4, fixed: true}, // rdev
+		{data: encodeString(symlinkTarget), align: 1, fixed: false},
+		{data: encodeXattrs(xattrs), align: 1, fixed: false},
+	}
+	return serTuple(members)
+}
+
+// EncodeFileMeta serializes the ostree "(uuua(ayay))" filemeta GVariant =
+// (uid, gid, mode, xattrs). This is the value stored in the bare-user
+// "user.ostreemeta" xattr.
+func EncodeFileMeta(uid, gid, mode uint32, xattrs []Xattr) []byte {
+	members := []member{
+		{data: beU32(uid), align: 4, fixed: true},
+		{data: beU32(gid), align: 4, fixed: true},
+		{data: beU32(mode), align: 4, fixed: true},
+		{data: encodeXattrs(xattrs), align: 1, fixed: false},
+	}
+	return serTuple(members)
+}
+
+// member is one serialized tuple member: its bytes, alignment, and whether it is
+// fixed-size (fixed members never carry a framing offset).
+type member struct {
+	data  []byte
+	align int
+	fixed bool
+}
+
+// beU32 encodes x as 4 big-endian bytes (see endianness note above).
+func beU32(x uint32) []byte {
+	return []byte{byte(x >> 24), byte(x >> 16), byte(x >> 8), byte(x)}
+}
+
+// encodeString serializes a GVariant string 's': the bytes plus a trailing NUL.
+func encodeString(s string) []byte {
+	b := make([]byte, 0, len(s)+1)
+	b = append(b, s...)
+	b = append(b, 0)
+	return b
+}
+
+// encodeXattrs serializes an a(ayay) array of (name, value) byte-array pairs. An
+// empty array serializes to zero bytes. The name's terminating NUL is appended
+// here, matching how ostree stores xattr names.
+func encodeXattrs(xattrs []Xattr) []byte {
+	if len(xattrs) == 0 {
+		return nil
+	}
+	elems := make([][]byte, len(xattrs))
+	for i, xa := range xattrs {
+		name := make([]byte, 0, len(xa.Name)+1)
+		name = append(name, xa.Name...)
+		name = append(name, 0)
+		// (ayay): two variable byte-array members; the first (name) carries a
+		// framing offset, the last (value) does not.
+		elems[i] = serTuple([]member{
+			{data: name, align: 1, fixed: false},
+			{data: xa.Value, align: 1, fixed: false},
+		})
+	}
+	return serArrayVar(elems, 1)
+}
+
+// padTo grows b with zero bytes until its length is a multiple of align.
+func padTo(b []byte, align int) []byte {
+	for align > 1 && len(b)%align != 0 {
+		b = append(b, 0)
+	}
+	return b
+}
+
+// putLE writes v as size little-endian bytes into b[:size].
+func putLE(b []byte, v uint64, size int) {
+	for i := 0; i < size; i++ {
+		b[i] = byte(v >> (8 * i))
+	}
+}
+
+// offsetSizeFor mirrors GLib's gvs_get_offset_size: the width needed to store an
+// offset into a container of the given total size.
+func offsetSizeFor(size int) int {
+	switch {
+	case size > 0xFFFFFFFF:
+		return 8
+	case size > 0xFFFF:
+		return 4
+	case size > 0xFF:
+		return 2
+	case size > 0:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// chooseOffsetSize finds the smallest framing-offset width that is self
+// consistent: large enough to address the container once its own offset bytes
+// are included.
+func chooseOffsetSize(bodyLen, nOff int) int {
+	sz := 1
+	for {
+		total := bodyLen + nOff*sz
+		need := offsetSizeFor(total)
+		if need <= sz {
+			return sz
+		}
+		sz = need
+	}
+}
+
+// serTuple serializes tuple members per the GVariant framing rules. Variable
+// -size members other than the final member each contribute a framing offset
+// (the byte position of their end); those offsets are stored at the tail in
+// reverse framing order (framing index 0 rightmost).
+func serTuple(members []member) []byte {
+	var body []byte
+	var offsets []int // end positions, in framing-index order
+	n := len(members)
+	for i, m := range members {
+		body = padTo(body, m.align)
+		body = append(body, m.data...)
+		if !m.fixed && i != n-1 {
+			offsets = append(offsets, len(body))
+		}
+	}
+	nOff := len(offsets)
+	if nOff == 0 {
+		return body
+	}
+	offSize := chooseOffsetSize(len(body), nOff)
+	out := make([]byte, len(body)+nOff*offSize)
+	copy(out, body)
+	size := len(out)
+	for k := 0; k < nOff; k++ {
+		putLE(out[size-offSize*(k+1):], uint64(offsets[k]), offSize)
+	}
+	return out
+}
+
+// serArrayVar serializes an array of variable-size elements. Each element is
+// aligned to elemAlign; one framing offset per element (its end position) is
+// stored at the tail in forward order. An empty array is zero bytes.
+func serArrayVar(elems [][]byte, elemAlign int) []byte {
+	var body []byte
+	offsets := make([]int, 0, len(elems))
+	for _, e := range elems {
+		body = padTo(body, elemAlign)
+		body = append(body, e...)
+		offsets = append(offsets, len(body))
+	}
+	n := len(offsets)
+	if n == 0 {
+		return nil
+	}
+	offSize := chooseOffsetSize(len(body), n)
+	out := make([]byte, len(body)+n*offSize)
+	copy(out, body)
+	base := len(body)
+	for k := 0; k < n; k++ {
+		putLE(out[base+k*offSize:], uint64(offsets[k]), offSize)
+	}
+	return out
+}

--- a/pkg/gvariant/encode_test.go
+++ b/pkg/gvariant/encode_test.go
@@ -1,0 +1,88 @@
+package gvariant
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+// Ground-truth bytes captured from libostree 2024.5 (GLib.Variant) on the box,
+// for uid=1001 (0x3e9), gid=1002 (0x3ea), mode=0100664 (0x81b4) / symlink mode
+// 0120777 (0xa1ff). These pin the exact serialization (including big-endian
+// ints and framing offsets).
+func TestEncodeFileHeaderRegfile(t *testing.T) {
+	got := EncodeFileHeader(1001, 1002, 0o100664, "", nil)
+	want := "000003e9000003ea000081b4000000000011"
+	if hex.EncodeToString(got) != want {
+		t.Errorf("regfile header:\n got %s\nwant %s", hex.EncodeToString(got), want)
+	}
+}
+
+func TestEncodeFileHeaderSymlink(t *testing.T) {
+	got := EncodeFileHeader(1001, 1002, 0o120777, "regfile.txt", nil)
+	want := "000003e9000003ea0000a1ff0000000072656766696c652e747874001c"
+	if hex.EncodeToString(got) != want {
+		t.Errorf("symlink header:\n got %s\nwant %s", hex.EncodeToString(got), want)
+	}
+}
+
+func TestEncodeFileMetaRegfile(t *testing.T) {
+	got := EncodeFileMeta(1001, 1002, 0o100664, nil)
+	want := "000003e9000003ea000081b4"
+	if hex.EncodeToString(got) != want {
+		t.Errorf("meta:\n got %s\nwant %s", hex.EncodeToString(got), want)
+	}
+}
+
+func TestEncodeFileMetaWithXattr(t *testing.T) {
+	xa := []Xattr{{Name: []byte("user.foo"), Value: []byte("bar")}}
+	got := EncodeFileMeta(1001, 1002, 0o100664, xa)
+	want := "000003e9000003ea000081b4757365722e666f6f00626172090d"
+	if hex.EncodeToString(got) != want {
+		t.Errorf("meta w/xattr:\n got %s\nwant %s", hex.EncodeToString(got), want)
+	}
+}
+
+func TestEncodeFileHeaderWithXattr(t *testing.T) {
+	xa := []Xattr{{Name: []byte("user.foo"), Value: []byte("bar")}}
+	got := EncodeFileHeader(1001, 1002, 0o100664, "", xa)
+	want := "000003e9000003ea000081b40000000000757365722e666f6f00626172090d11"
+	if hex.EncodeToString(got) != want {
+		t.Errorf("header w/xattr:\n got %s\nwant %s", hex.EncodeToString(got), want)
+	}
+}
+
+// Round-trip: the encoded meta must decode back to the same fields via the
+// decoder in this package.
+func TestEncodeMetaRoundTrip(t *testing.T) {
+	xa := []Xattr{{Name: []byte("user.foo"), Value: []byte("bar")}}
+	raw := EncodeFileMeta(1001, 1002, 0o100664, xa)
+	v, err := New(raw, "(uuua(ayay))")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Ints are stored big-endian here, so read the bytes back big-endian.
+	if got := beFromBytes(v.Child(0).Raw()); got != 1001 {
+		t.Errorf("uid: got %d want 1001", got)
+	}
+	if got := beFromBytes(v.Child(2).Raw()); got != 0o100664 {
+		t.Errorf("mode: got %o want 0100664", got)
+	}
+	arr := v.Child(3)
+	if arr.Len() != 1 {
+		t.Fatalf("xattrs len: got %d want 1", arr.Len())
+	}
+	e := arr.At(0)
+	if string(e.Child(0).Bytes()) != "user.foo\x00" {
+		t.Errorf("xattr name: got %q", string(e.Child(0).Bytes()))
+	}
+	if string(e.Child(1).Bytes()) != "bar" {
+		t.Errorf("xattr value: got %q", string(e.Child(1).Bytes()))
+	}
+	if err := v.Err(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func beFromBytes(b []byte) uint32 {
+	return uint32(b[0])<<24 | uint32(b[1])<<16 | uint32(b[2])<<8 | uint32(b[3])
+}

--- a/pkg/gvariant/gvariant.go
+++ b/pkg/gvariant/gvariant.go
@@ -1,0 +1,306 @@
+// Package gvariant is a minimal, pure-Go deserializer for the GVariant binary
+// serialization format (little-endian), sufficient for reading the GVariant
+// objects ostree stores on disk: static-delta superblocks, commits, dirtrees
+// and dirmeta.
+//
+// It implements the framing rules from GLib's gvariant-serialiser.c /
+// gvarianttypeinfo.c (the "magic constant" tuple member-bounds algorithm and
+// the variable-sized-array framing-offset scheme). No cgo, no GLib.
+//
+// The API is value-oriented with a deferred error: navigate with Child/At, read
+// leaves with Uint64/Bytes/Str, then check Err once at the end. Any access on a
+// Value that already carries an error is a no-op returning the zero value, so a
+// chain of accesses never panics on malformed input.
+package gvariant
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Value is a GVariant value: a type plus the byte slice holding its serialized
+// form. The zero Value is not usable; obtain one from New.
+type Value struct {
+	typ  *Type
+	data []byte
+	err  error
+}
+
+// New parses the type signature typ and wraps data as a Value of that type.
+// It does not eagerly validate framing; malformed framing surfaces as an error
+// from the accessor that touches it (retrievable via Err).
+func New(data []byte, typ string) (*Value, error) {
+	t, n, err := parseType(typ, 0)
+	if err != nil {
+		return nil, err
+	}
+	if n != len(typ) {
+		return nil, fmt.Errorf("gvariant: trailing characters in type %q", typ)
+	}
+	return &Value{typ: t, data: data}, nil
+}
+
+// Err returns the first error encountered while navigating from this Value
+// (and its ancestors). Check it once after a chain of accesses.
+func (v *Value) Err() error { return v.err }
+
+func (v *Value) fail(format string, a ...any) *Value {
+	if v.err == nil {
+		v.err = fmt.Errorf("gvariant: "+format, a...)
+	}
+	return v
+}
+
+// Type returns the value's type signature, e.g. "(uayttay)".
+func (v *Value) Type() string { return v.typ.String() }
+
+// readLE reads a little-endian unsigned integer from the first size bytes of b.
+func readLE(b []byte, size uint64) uint64 {
+	var x uint64
+	for i := uint64(0); i < size; i++ {
+		x |= uint64(b[i]) << (8 * i)
+	}
+	return x
+}
+
+// offsetSize returns the width in bytes of each framing offset for a container
+// whose total serialized size is size (GLib's gvs_get_offset_size).
+func offsetSize(size uint64) uint64 {
+	switch {
+	case size > 0xFFFFFFFF:
+		return 8
+	case size > 0xFFFF:
+		return 4
+	case size > 0xFF:
+		return 2
+	case size > 0:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// alignUp rounds x up to the next multiple of align (a power of two).
+func alignUp(x, align uint64) uint64 {
+	return x + ((-x) & (align - 1))
+}
+
+// Child returns the i-th member of a tuple (or dict-entry) value.
+func (v *Value) Child(i int) *Value {
+	if v.err != nil {
+		return v
+	}
+	if v.typ.kind != kindTuple && v.typ.kind != kindDict {
+		return (&Value{err: v.err}).fail("Child on non-tuple type %q", v.typ.String())
+	}
+	members := v.typ.members()
+	if i < 0 || i >= len(members) {
+		return (&Value{}).fail("tuple child %d out of range (%d members)", i, len(members))
+	}
+	m := members[i]
+	size := uint64(len(v.data))
+	os := offsetSize(size)
+
+	// Start of the member: read the framing offset that marks the end of the
+	// previous variable-sized member (if any), then apply the precomputed
+	// align/add constants. (GLib gvs_tuple_get_member_bounds.)
+	var raw uint64
+	if m.i+1 != 0 && os*uint64(m.i+1) <= size {
+		raw = readLE(v.data[size-os*uint64(m.i+1):], os)
+	}
+	start := ((raw + m.a) & m.b) | m.c
+
+	var end uint64
+	switch m.ending {
+	case endingLast:
+		if os*uint64(m.i+1) <= size {
+			end = size - os*uint64(m.i+1)
+		} else {
+			return (&Value{}).fail("tuple member %d: bad LAST framing", i)
+		}
+	case endingFixed:
+		end = start + m.fixed
+	case endingOffset:
+		if os*uint64(m.i+2) <= size {
+			end = readLE(v.data[size-os*uint64(m.i+2):], os)
+		} else {
+			return (&Value{}).fail("tuple member %d: bad OFFSET framing", i)
+		}
+	}
+	if start > end || end > size {
+		return (&Value{}).fail("tuple member %d: bounds [%d,%d] exceed size %d", i, start, end, size)
+	}
+	return &Value{typ: m.typ, data: v.data[start:end]}
+}
+
+// Len returns the number of elements in an array value.
+func (v *Value) Len() int {
+	if v.err != nil {
+		return 0
+	}
+	if v.typ.kind != kindArray {
+		v.fail("Len on non-array type %q", v.typ.String())
+		return 0
+	}
+	size := uint64(len(v.data))
+	elem := v.typ.elem
+	if elem.fixed != 0 {
+		// Array of fixed-size elements: no framing offsets.
+		if size%elem.fixed != 0 {
+			v.fail("fixed array size %d not a multiple of element size %d", size, elem.fixed)
+			return 0
+		}
+		return int(size / elem.fixed)
+	}
+	if size == 0 {
+		return 0
+	}
+	os := offsetSize(size)
+	lastEnd := readLE(v.data[size-os:], os)
+	if lastEnd > size {
+		v.fail("array framing: last offset %d exceeds size %d", lastEnd, size)
+		return 0
+	}
+	offsetsBytes := size - lastEnd
+	if offsetsBytes%os != 0 {
+		v.fail("array framing: offset region %d not a multiple of offset size %d", offsetsBytes, os)
+		return 0
+	}
+	return int(offsetsBytes / os)
+}
+
+// At returns the i-th element of an array value.
+func (v *Value) At(i int) *Value {
+	if v.err != nil {
+		return v
+	}
+	if v.typ.kind != kindArray {
+		return (&Value{}).fail("At on non-array type %q", v.typ.String())
+	}
+	size := uint64(len(v.data))
+	elem := v.typ.elem
+	if elem.fixed != 0 {
+		start := uint64(i) * elem.fixed
+		end := start + elem.fixed
+		if end > size {
+			return (&Value{}).fail("fixed array element %d out of range", i)
+		}
+		return &Value{typ: elem, data: v.data[start:end]}
+	}
+	// Variable-sized elements: framing offsets live at the tail.
+	os := offsetSize(size)
+	lastEnd := readLE(v.data[size-os:], os)
+	arr := v.data[lastEnd:]
+	var start uint64
+	if i > 0 {
+		start = readLE(arr[os*uint64(i-1):], os)
+		start = alignUp(start, elem.align)
+	}
+	end := readLE(arr[os*uint64(i):], os)
+	if start > end || end > size {
+		return (&Value{}).fail("array element %d: bounds [%d,%d] exceed size %d", i, start, end, size)
+	}
+	return &Value{typ: elem, data: v.data[start:end]}
+}
+
+// Variant unwraps a variant ('v') value into its contained Value.
+func (v *Value) Variant() *Value {
+	if v.err != nil {
+		return v
+	}
+	if v.typ.kind != kindVariant {
+		return (&Value{}).fail("Variant on non-variant type %q", v.typ.String())
+	}
+	// Serialized form: <child data> 0x00 <type signature>.
+	sep := -1
+	for i := len(v.data) - 1; i >= 0; i-- {
+		if v.data[i] == 0 {
+			sep = i
+			break
+		}
+	}
+	if sep < 0 {
+		return (&Value{}).fail("variant: no type separator")
+	}
+	child, err := New(v.data[:sep], string(v.data[sep+1:]))
+	if err != nil {
+		return (&Value{}).fail("variant: %v", err)
+	}
+	return child
+}
+
+// Uint64 reads a 't' (uint64) leaf.
+func (v *Value) Uint64() uint64 {
+	if v.err != nil {
+		return 0
+	}
+	if len(v.data) < 8 {
+		v.fail("Uint64: need 8 bytes, have %d", len(v.data))
+		return 0
+	}
+	return readLE(v.data, 8)
+}
+
+// Uint32 reads a 'u' (uint32) leaf.
+func (v *Value) Uint32() uint32 {
+	if v.err != nil {
+		return 0
+	}
+	if len(v.data) < 4 {
+		v.fail("Uint32: need 4 bytes, have %d", len(v.data))
+		return 0
+	}
+	return uint32(readLE(v.data, 4))
+}
+
+// Byte reads a 'y' (uint8) leaf.
+func (v *Value) Byte() byte {
+	if v.err != nil {
+		return 0
+	}
+	if len(v.data) < 1 {
+		v.fail("Byte: empty data")
+		return 0
+	}
+	return v.data[0]
+}
+
+// Raw returns the value's underlying serialized bytes. For a fixed-size leaf
+// (e.g. 'u'/'t') these are the integer bytes in their stored byte order.
+func (v *Value) Raw() []byte {
+	if v.err != nil {
+		return nil
+	}
+	return v.data
+}
+
+// Bytes returns the raw bytes of an 'ay' (byte array) value.
+func (v *Value) Bytes() []byte {
+	if v.err != nil {
+		return nil
+	}
+	if v.typ.kind != kindArray || v.typ.elem.kind != kindByte {
+		v.fail("Bytes on non-ay type %q", v.typ.String())
+		return nil
+	}
+	return v.data
+}
+
+// Str reads a string-like leaf ('s', 'o' or 'g'), stripping the trailing NUL.
+func (v *Value) Str() string {
+	if v.err != nil {
+		return ""
+	}
+	if k := v.typ.kind; k != kindString && k != kindObjPath && k != kindSignature {
+		v.fail("Str on non-string type %q", v.typ.String())
+		return ""
+	}
+	d := v.data
+	if len(d) > 0 && d[len(d)-1] == 0 {
+		d = d[:len(d)-1]
+	}
+	return string(d)
+}
+
+// ErrType is returned for unsupported or malformed type signatures.
+var ErrType = errors.New("gvariant: bad type")

--- a/pkg/gvariant/gvariant_test.go
+++ b/pkg/gvariant/gvariant_test.go
@@ -1,0 +1,115 @@
+package gvariant
+
+import (
+	"bytes"
+	"testing"
+)
+
+// Test tuple member-bounds for the meta-entry type "(uayttay)", whose framing is
+// the heart of superblock parsing. Construct one entry by hand and read it back.
+//
+// Layout of (u ay t t ay):
+//
+//	u  version  @0 (4 bytes, fixed)
+//	ay csum     @4 (variable) -> needs a framing offset
+//	t  size     @aligned(8)   (fixed)
+//	t  usize                  (fixed)
+//	ay objs     (variable, LAST) -> end = size - offsets
+func TestTupleMetaEntry(t *testing.T) {
+	// Build: version=1, csum=[2 bytes 0xAA,0xBB], size=0x1122, usize=0x3344,
+	// objs=[0x09].
+	var buf bytes.Buffer
+	// version u @0
+	buf.Write([]byte{1, 0, 0, 0})
+	// csum ay (2 bytes) @4
+	buf.Write([]byte{0xAA, 0xBB})
+	// pad to align 8 for the first t: current len=6 -> pad 2
+	buf.Write([]byte{0, 0})
+	// size t @8
+	buf.Write(le64(0x1122))
+	// usize t @16
+	buf.Write(le64(0x3344))
+	// objs ay (LAST) @24
+	buf.Write([]byte{0x09})
+	// framing offsets (one, for the first variable member 'csum'): its end = 6.
+	// The last member is LAST so it has no stored offset. offset_size for this
+	// small container is 1.
+	buf.WriteByte(6)
+
+	v, err := New(buf.Bytes(), "(uayttay)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := v.Child(0).Uint32(); got != 1 {
+		t.Errorf("version: got %d want 1", got)
+	}
+	if got := v.Child(1).Bytes(); !bytes.Equal(got, []byte{0xAA, 0xBB}) {
+		t.Errorf("csum: got %x want aabb", got)
+	}
+	if got := v.Child(2).Uint64(); got != 0x1122 {
+		t.Errorf("size: got %#x want 0x1122", got)
+	}
+	if got := v.Child(3).Uint64(); got != 0x3344 {
+		t.Errorf("usize: got %#x want 0x3344", got)
+	}
+	if got := v.Child(4).Bytes(); !bytes.Equal(got, []byte{0x09}) {
+		t.Errorf("objs: got %x want 09", got)
+	}
+	if err := v.Err(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Test a variable-sized array of strings "as" with two elements.
+func TestArrayOfStrings(t *testing.T) {
+	// "ab\0" (3) then "cde\0" (4). Offsets: [3, 7], offset_size=1.
+	data := []byte{'a', 'b', 0, 'c', 'd', 'e', 0, 3, 7}
+	v, err := New(data, "as")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.Len() != 2 {
+		t.Fatalf("len: got %d want 2", v.Len())
+	}
+	if got := v.At(0).Str(); got != "ab" {
+		t.Errorf("elem0: got %q want ab", got)
+	}
+	if got := v.At(1).Str(); got != "cde" {
+		t.Errorf("elem1: got %q want cde", got)
+	}
+	if err := v.Err(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Test an array of fixed-size elements "at" (no framing offsets).
+func TestArrayFixed(t *testing.T) {
+	var buf bytes.Buffer
+	buf.Write(le64(10))
+	buf.Write(le64(20))
+	buf.Write(le64(30))
+	v, err := New(buf.Bytes(), "at")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.Len() != 3 {
+		t.Fatalf("len: got %d want 3", v.Len())
+	}
+	want := []uint64{10, 20, 30}
+	for i, w := range want {
+		if got := v.At(i).Uint64(); got != w {
+			t.Errorf("elem%d: got %d want %d", i, got, w)
+		}
+	}
+	if err := v.Err(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func le64(x uint64) []byte {
+	b := make([]byte, 8)
+	for i := 0; i < 8; i++ {
+		b[i] = byte(x >> (8 * i))
+	}
+	return b
+}

--- a/pkg/gvariant/type.go
+++ b/pkg/gvariant/type.go
@@ -1,0 +1,274 @@
+package gvariant
+
+import "fmt"
+
+// kind enumerates the GVariant type classes this decoder understands.
+type kind int
+
+const (
+	kindByte      kind = iota // y
+	kindBool                  // b
+	kindUint16                // q
+	kindInt16                 // n
+	kindUint32                // u
+	kindInt32                 // i
+	kindUint64                // t
+	kindInt64                 // x
+	kindDouble                // d
+	kindString                // s
+	kindObjPath               // o
+	kindSignature             // g
+	kindVariant               // v
+	kindArray                 // a<elem>
+	kindTuple                 // (...)
+	kindDict                  // {kv} dict entry
+)
+
+// Type is a parsed GVariant type. fixed is the fixed serialized size (0 for
+// variable-sized types); align is the alignment requirement in bytes.
+type Type struct {
+	kind  kind
+	fixed uint64 // 0 => variable size
+	align uint64
+
+	elem  *Type   // array element / nil
+	mtyps []*Type // tuple/dict member types
+
+	// memberInfo is the precomputed per-member framing table for tuples/dicts,
+	// mirroring GLib's GVariantMemberInfo. Built lazily by members().
+	memberInfo []memberInfo
+}
+
+// ending classifies how a tuple member's end is located.
+type ending int
+
+const (
+	endingFixed  ending = iota // member is fixed-size; end = start + fixed
+	endingOffset               // end read from a framing offset
+	endingLast                 // last variable member; end = size - offsets
+)
+
+// memberInfo holds the "magic constants" (a, b, c, i) used to locate a tuple
+// member, per GLib gvarianttypeinfo.c. start = ((prev_end + a) & b) | c.
+type memberInfo struct {
+	typ    *Type
+	a      uint64
+	b      uint64
+	c      uint64
+	i      int // index of the framing offset to read for prev_end; -1 if none
+	ending ending
+	fixed  uint64
+}
+
+// parseType parses one complete type starting at s[i], returning the Type and
+// the index just past it.
+func parseType(s string, i int) (*Type, int, error) {
+	if i >= len(s) {
+		return nil, i, fmt.Errorf("%w: unexpected end of %q", ErrType, s)
+	}
+	switch s[i] {
+	case 'y':
+		return &Type{kind: kindByte, fixed: 1, align: 1}, i + 1, nil
+	case 'b':
+		return &Type{kind: kindBool, fixed: 1, align: 1}, i + 1, nil
+	case 'q':
+		return &Type{kind: kindUint16, fixed: 2, align: 2}, i + 1, nil
+	case 'n':
+		return &Type{kind: kindInt16, fixed: 2, align: 2}, i + 1, nil
+	case 'u':
+		return &Type{kind: kindUint32, fixed: 4, align: 4}, i + 1, nil
+	case 'i':
+		return &Type{kind: kindInt32, fixed: 4, align: 4}, i + 1, nil
+	case 't':
+		return &Type{kind: kindUint64, fixed: 8, align: 8}, i + 1, nil
+	case 'x':
+		return &Type{kind: kindInt64, fixed: 8, align: 8}, i + 1, nil
+	case 'd':
+		return &Type{kind: kindDouble, fixed: 8, align: 8}, i + 1, nil
+	case 's':
+		return &Type{kind: kindString, align: 1}, i + 1, nil
+	case 'o':
+		return &Type{kind: kindObjPath, align: 1}, i + 1, nil
+	case 'g':
+		return &Type{kind: kindSignature, align: 1}, i + 1, nil
+	case 'v':
+		return &Type{kind: kindVariant, align: 8}, i + 1, nil
+	case 'a':
+		elem, j, err := parseType(s, i+1)
+		if err != nil {
+			return nil, j, err
+		}
+		// An array is always variable-sized in serialized form; its alignment
+		// equals the element's alignment.
+		return &Type{kind: kindArray, elem: elem, align: elem.align}, j, nil
+	case '(', '{':
+		open := s[i]
+		close := byte(')')
+		k := kindTuple
+		if open == '{' {
+			close = '}'
+			k = kindDict
+		}
+		var members []*Type
+		j := i + 1
+		for j < len(s) && s[j] != close {
+			m, nj, err := parseType(s, j)
+			if err != nil {
+				return nil, nj, err
+			}
+			members = append(members, m)
+			j = nj
+		}
+		if j >= len(s) || s[j] != close {
+			return nil, j, fmt.Errorf("%w: unterminated tuple in %q", ErrType, s)
+		}
+		t := &Type{kind: k, mtyps: members}
+		computeTupleLayout(t)
+		return t, j + 1, nil
+	default:
+		return nil, i, fmt.Errorf("%w: unknown type char %q", ErrType, string(s[i]))
+	}
+}
+
+// computeTupleLayout fills fixed size, alignment, and the member framing table
+// for a tuple/dict, mirroring GLib's tuple_generate_table + tuple_set_base_info.
+func computeTupleLayout(t *Type) {
+	// Alignment is the max of member alignments.
+	var align uint64 = 1
+	for _, m := range t.mtyps {
+		if m.align > align {
+			align = m.align
+		}
+	}
+	t.align = align
+
+	// tuple_generate_table: maintain (a, b, c) such that to reach the current
+	// position you add a, align to b (one-less form), then add c. i tracks the
+	// framing-offset index of the last variable-sized member seen.
+	info := make([]memberInfo, len(t.mtyps))
+	var (
+		i       = -1
+		a, b, c uint64
+	)
+	for idx, m := range t.mtyps {
+		d := m.align - 1 // alignment in one-less form
+		e := m.fixed     // 0 for variable size
+
+		// align to d (rules 1 & 2)
+		if d <= b {
+			c = alignDownOneLess(c, d)
+		} else {
+			a += alignDownOneLess(c, b)
+			b = d
+			c = 0
+		}
+
+		// tuple_table_append's a/b/c tweaks.
+		na := a + (^b & c)
+		nc := c & b
+		mi := memberInfo{
+			typ:   m,
+			a:     na + b,
+			b:     ^b,
+			c:     nc,
+			i:     i,
+			fixed: m.fixed,
+		}
+		if m.fixed != 0 {
+			mi.ending = endingFixed
+		} else if idx == len(t.mtyps)-1 {
+			mi.ending = endingLast
+		} else {
+			mi.ending = endingOffset
+		}
+		info[idx] = mi
+
+		// move past the item
+		if e == 0 {
+			i++
+			a, b, c = 0, 0, 0
+		} else {
+			c += e
+		}
+	}
+	t.memberInfo = info
+
+	// A tuple is fixed-size iff it contains no variable-sized members and is
+	// non-empty; then fixed = its aligned total size. GLib treats the empty
+	// tuple as fixed size 1.
+	if len(t.mtyps) == 0 {
+		t.fixed = 1
+		return
+	}
+	fixed := true
+	for _, m := range t.mtyps {
+		if m.fixed == 0 {
+			fixed = false
+			break
+		}
+	}
+	if fixed {
+		// Total size = sum of members with alignment padding, rounded to align.
+		var size uint64
+		for _, m := range t.mtyps {
+			size = alignUp(size, m.align)
+			size += m.fixed
+		}
+		size = alignUp(size, t.align)
+		t.fixed = size
+	}
+}
+
+// alignDownOneLess aligns x up to (oneLess+1), where oneLess is an alignment in
+// "one less than a power of two" form. This is GLib's tuple_align.
+func alignDownOneLess(x, oneLess uint64) uint64 {
+	return x + ((-x) & oneLess)
+}
+
+// members returns the precomputed framing table.
+func (t *Type) members() []memberInfo { return t.memberInfo }
+
+// String renders the type signature.
+func (t *Type) String() string {
+	switch t.kind {
+	case kindByte:
+		return "y"
+	case kindBool:
+		return "b"
+	case kindUint16:
+		return "q"
+	case kindInt16:
+		return "n"
+	case kindUint32:
+		return "u"
+	case kindInt32:
+		return "i"
+	case kindUint64:
+		return "t"
+	case kindInt64:
+		return "x"
+	case kindDouble:
+		return "d"
+	case kindString:
+		return "s"
+	case kindObjPath:
+		return "o"
+	case kindSignature:
+		return "g"
+	case kindVariant:
+		return "v"
+	case kindArray:
+		return "a" + t.elem.String()
+	case kindTuple, kindDict:
+		open, close := "(", ")"
+		if t.kind == kindDict {
+			open, close = "{", "}"
+		}
+		s := open
+		for _, m := range t.mtyps {
+			s += m.String()
+		}
+		return s + close
+	}
+	return "?"
+}

--- a/pkg/ostree/b64.go
+++ b/pkg/ostree/b64.go
@@ -1,0 +1,62 @@
+package ostree
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+// ostreeB64 is the "modified base64" ostree uses for on-disk delta directory
+// names: standard base64 with '/' replaced by '_' and no '=' padding. See
+// ostree_checksum_b64_inplace_from_bytes in libostree (ostree-core.c).
+var ostreeB64 = base64.StdEncoding.WithPadding(base64.NoPadding)
+
+// digestToB64 encodes a 64-hex commit checksum to ostree's modified base64
+// (43 chars). It is the Go equivalent of ostree's
+// ostree_checksum_inplace_to_bytes + ostree_checksum_b64_inplace_from_bytes.
+func digestToB64(hexCsum string) (string, error) {
+	raw, err := hex.DecodeString(hexCsum)
+	if err != nil {
+		return "", fmt.Errorf("bad checksum %q: %w", hexCsum, err)
+	}
+	if len(raw) != 32 {
+		return "", fmt.Errorf("bad checksum %q: want 32 bytes, got %d", hexCsum, len(raw))
+	}
+	return strings.ReplaceAll(ostreeB64.EncodeToString(raw), "/", "_"), nil
+}
+
+// staticDeltaDir returns the repo-relative directory of the from->to static
+// delta, mirroring libostree's static_delta_path_base (ostree-core.c):
+//
+//	from set:  deltas/<B(to)[0:2]>/<B(from)[2:]>-<B(to)>
+//	from empty: deltas/<B(to)[0:2]>/<B(to)[2:]>
+//
+// where B is digestToB64.
+func staticDeltaDir(from, to string) (string, error) {
+	if to == "" {
+		return "", fmt.Errorf("empty 'to' commit")
+	}
+	bTo, err := digestToB64(to)
+	if err != nil {
+		return "", err
+	}
+	var sb strings.Builder
+	sb.WriteString("deltas/")
+	if from != "" {
+		bFrom, err := digestToB64(from)
+		if err != nil {
+			return "", err
+		}
+		sb.WriteString(bFrom[:2])
+		sb.WriteByte('/')
+		sb.WriteString(bFrom[2:])
+		sb.WriteByte('-')
+		sb.WriteString(bTo)
+	} else {
+		sb.WriteString(bTo[:2])
+		sb.WriteByte('/')
+		sb.WriteString(bTo[2:])
+	}
+	return sb.String(), nil
+}

--- a/pkg/ostree/bareuser.go
+++ b/pkg/ostree/bareuser.go
@@ -1,0 +1,244 @@
+//go:build linux
+
+package ostree
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/foundriesio/ostreeuploader/pkg/gvariant"
+)
+
+// xattrOstreeMeta is the user xattr under which bare-user repos store a content
+// object's (uuua(ayay)) file metadata.
+const xattrOstreeMeta = "user.ostreemeta"
+
+// ensureRepo creates the directory skeleton and config of a bare-user(-only)
+// repo at r.path if it is not already initialized. The mode is r.initMode when
+// set, else bare-user. It is idempotent.
+func (r *Repo) ensureRepo() error {
+	cfg := filepath.Join(r.path, "config")
+	if _, err := os.Stat(cfg); err == nil {
+		return nil // already initialized
+	}
+	for _, d := range []string{
+		"objects", "refs/heads", "refs/remotes", "refs/mirrors", "state", "tmp",
+	} {
+		if err := os.MkdirAll(filepath.Join(r.path, d), 0o755); err != nil {
+			return fmt.Errorf("init repo: %w", err)
+		}
+	}
+	mode := r.initMode
+	if mode == "" {
+		mode = modeBareUser
+	}
+	conf := "[core]\nrepo_version=1\nmode=" + mode + "\n"
+	if err := os.WriteFile(cfg, []byte(conf), 0o644); err != nil {
+		return fmt.Errorf("write repo config: %w", err)
+	}
+	return nil
+}
+
+// hasObject reports whether the loose object <csum>.<ext> already exists.
+func (r *Repo) hasObject(csum, ext string) bool {
+	_, err := os.Stat(r.objectPath(csum, ext))
+	return err == nil
+}
+
+// writeFileAtomic writes data to a fresh temp file in the repo's objects dir,
+// applies prepare (e.g. to set an xattr) on the temp path while it is still
+// hidden, then renames it into place at dst. The parent dir of dst is created
+// if missing.
+func (r *Repo) writeFileAtomic(dst string, data []byte, mode os.FileMode, prepare func(path string) error) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(dst), ".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() {
+		tmp.Close()
+		os.Remove(tmpName) // no-op if already renamed
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		return wrapENOSPC(err)
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		return err
+	}
+	// fsync the data before the rename so a power failure cannot leave a renamed
+	// but empty/torn object in the content-addressed store.
+	if err := tmp.Sync(); err != nil {
+		return wrapENOSPC(err)
+	}
+	if err := tmp.Close(); err != nil {
+		return wrapENOSPC(err)
+	}
+	if prepare != nil {
+		if err := prepare(tmpName); err != nil {
+			return err
+		}
+	}
+	if err := wrapENOSPC(os.Rename(tmpName, dst)); err != nil {
+		return err
+	}
+	// fsync the parent directory so the rename itself survives a power failure.
+	return syncDir(filepath.Dir(dst))
+}
+
+// syncDir flushes a directory entry change (e.g. a rename into it) to disk.
+func syncDir(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	return d.Sync()
+}
+
+// writeMetadataObject writes a commit/dirtree/dirmeta object verbatim after
+// verifying its checksum equals sha256(raw bytes). ext is "commit", "dirtree",
+// "dirmeta" or "commitmeta".
+func (r *Repo) writeMetadataObject(csum, ext string, raw []byte) error {
+	if ext != "commitmeta" { // detached metadata is not content-addressed by its own bytes
+		if got := hex.EncodeToString(sha256Sum(raw)); got != csum {
+			return fmt.Errorf("%s object %s: checksum mismatch (got %s)", ext, csum, got)
+		}
+	}
+	return r.writeFileAtomic(r.objectPath(csum, ext), raw, 0o644, nil)
+}
+
+// writeContentObject converts a parsed content object into a loose object in the
+// destination repo's mode, after verifying its checksum:
+//
+//   - bare-user: regular file body (or symlink target + trailing NUL), with the
+//     (uuua(ayay)) file metadata stored in the user.ostreemeta xattr.
+//   - bare-user-only: a regular file whose physical mode is the canonical mode
+//     and no xattr, or a real on-disk symlink. uid/gid and xattrs are dropped
+//     (the format cannot store them); only the mode must be representable
+//     (fit 0775), else an error is returned.
+func (r *Repo) writeContentObject(csum string, h fileHeader, content []byte) error {
+	if got := contentObjectID(h, content); got != csum {
+		return fmt.Errorf("content object %s: checksum mismatch (got %s)", csum, got)
+	}
+	if r.repoMode() == modeBareUserOnly {
+		return r.writeContentObjectBareUserOnly(csum, h, content)
+	}
+	return r.writeContentObjectBareUser(csum, h, content)
+}
+
+// writeContentObjectBareUser writes a .file with the metadata held in the
+// user.ostreemeta xattr (symlink stored as target + trailing NUL).
+func (r *Repo) writeContentObjectBareUser(csum string, h fileHeader, content []byte) error {
+	var body []byte
+	if h.isSymlink() {
+		body = append([]byte(h.symlink), 0) // target + trailing NUL
+	} else {
+		body = content
+	}
+	meta := gvariant.EncodeFileMeta(h.uid, h.gid, h.mode, h.xattrs)
+	setMeta := func(path string) error {
+		if err := syscall.Setxattr(path, xattrOstreeMeta, meta, 0); err != nil {
+			return fmt.Errorf("set %s: %w", xattrOstreeMeta, err)
+		}
+		return nil
+	}
+	return r.writeFileAtomic(r.objectPath(csum, "file"), body, 0o644, setMeta)
+}
+
+// writeContentObjectBareUserOnly writes a .file in bare-user-only mode: a real
+// symlink, or a regular file whose physical permission bits carry the mode (no
+// xattr). It enforces the bare-user-only representability constraints.
+func (r *Repo) writeContentObjectBareUserOnly(csum string, h fileHeader, content []byte) error {
+	if h.isSymlink() {
+		// A real on-disk symlink; metadata is not stored (canonical uid/gid 0).
+		dst := r.objectPath(csum, "file")
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return err
+		}
+		// Symlink atomically via a temp name + rename.
+		tmp := dst + ".tmp"
+		_ = os.Remove(tmp)
+		if err := os.Symlink(h.symlink, tmp); err != nil {
+			return wrapENOSPC(err)
+		}
+		if err := os.Rename(tmp, dst); err != nil {
+			os.Remove(tmp)
+			return wrapENOSPC(err)
+		}
+		// fsync the parent directory so the symlink rename survives a power failure.
+		return syncDir(filepath.Dir(dst))
+	}
+	if err := validateBareUserOnly(csum, h); err != nil {
+		return err
+	}
+	// Physical mode carries the permission bits (libostree stores it verbatim
+	// after validation); type bits are implicit in being a regular file.
+	mode := os.FileMode(h.mode & 0o777)
+	return r.writeFileAtomic(r.objectPath(csum, "file"), content, mode, nil)
+}
+
+// validateBareUserOnly rejects content a bare-user-only repo cannot represent in
+// its mode bits: setuid/setgid/sticky or world-write (anything outside 0775).
+// This mirrors libostree's _ostree_validate_bareuseronly_mode, which validates
+// ONLY the mode. uid/gid and xattrs are not checked here: bare-user-only cannot
+// store them, so (like libostree) the writer simply drops them — published
+// rootfs content commonly has non-zero uid/gid, and libostree pulls it fine.
+func validateBareUserOnly(csum string, h fileHeader) error {
+	if bits := h.mode & 0o7777 &^ 0o775; bits != 0 {
+		return fmt.Errorf("content object %s: bare-user-only invalid mode %#o (forbidden bits %#o)", csum, h.mode&0o7777, bits)
+	}
+	return nil
+}
+
+// commitPartialPath returns the repo path of a commit's partial marker.
+func (r *Repo) commitPartialPath(commit string) string {
+	return filepath.Join(r.path, "state", commit+".commitpartial")
+}
+
+// markCommitPartial creates (partial=true) or removes (partial=false) the
+// state/<commit>.commitpartial marker. The marker signals that not all of the
+// commit's objects are present yet, enabling a safe resume.
+func (r *Repo) markCommitPartial(commit string, partial bool) error {
+	p := r.commitPartialPath(commit)
+	if partial {
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			return err
+		}
+		f, err := os.OpenFile(p, os.O_CREATE|os.O_WRONLY, 0o644)
+		if err != nil {
+			return err
+		}
+		return f.Close()
+	}
+	if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// isCommitPartial reports whether the commit is marked partial.
+func (r *Repo) isCommitPartial(commit string) bool {
+	_, err := os.Stat(r.commitPartialPath(commit))
+	return err == nil
+}
+
+// writeRef writes refs/heads/<ref> with the commit checksum.
+func (r *Repo) writeRef(ref, commit string) error {
+	p := filepath.Join(r.path, "refs", "heads", filepath.FromSlash(ref))
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(p, []byte(commit+"\n"), 0o644)
+}
+
+func sha256Sum(b []byte) []byte {
+	s := sha256.Sum256(b)
+	return s[:]
+}

--- a/pkg/ostree/bareuser_only_test.go
+++ b/pkg/ostree/bareuser_only_test.go
@@ -1,0 +1,82 @@
+//go:build linux
+
+package ostree
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/foundriesio/ostreeuploader/pkg/gvariant"
+)
+
+// TestPullBareUserOnly pulls into a bare-user-only destination repo and confirms
+// it is valid (ostree fsck) and matches the source listing. The source content
+// is root-owned (ostree commit canonicalizes uid/gid to 0), so it is
+// representable in bare-user-only.
+func TestPullBareUserOnly(t *testing.T) {
+	requireOstree(t)
+	srcRepo, ref, commit := makeContentRepoOpts(t, true) // root-owned: representable in bare-user-only
+	srv := httptest.NewServer(http.FileServer(http.Dir(srcRepo)))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "dest")
+	r := OpenRepo(dest).WithMode(modeBareUserOnly)
+	res, err := r.Pull(context.Background(), PullOptions{
+		Remote: RemoteConfig{BaseURL: srv.URL},
+		Ref:    ref,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Commit != commit {
+		t.Fatalf("commit %s want %s", res.Commit, commit)
+	}
+	if r.repoMode() != modeBareUserOnly {
+		t.Fatalf("dest repo mode = %q, want bare-user-only", r.repoMode())
+	}
+
+	out := run(t, "ostree", "--repo="+dest, "fsck")
+	if !strings.Contains(out, "no errors found") {
+		t.Errorf("fsck failed:\n%s", out)
+	}
+	// The symlink object must be a real symlink in bare-user-only mode.
+	srcLs := run(t, "ostree", "--repo="+srcRepo, "ls", "-R", commit)
+	dstLs := run(t, "ostree", "--repo="+dest, "ls", "-R", commit)
+	if srcLs != dstLs {
+		t.Errorf("listings differ:\n--- src ---\n%s\n--- dst ---\n%s", srcLs, dstLs)
+	}
+}
+
+// TestValidateBareUserOnly checks the mode guard: bare-user-only validates only
+// the mode bits (rejecting setuid/setgid/sticky/world-write). uid/gid and xattrs
+// are not rejected — the writer drops them, mirroring libostree.
+func TestValidateBareUserOnly(t *testing.T) {
+	cases := []struct {
+		name string
+		h    fileHeader
+		ok   bool
+	}{
+		{"root 0644", fileHeader{uid: 0, gid: 0, mode: 0o100644}, true},
+		{"root 0755", fileHeader{uid: 0, gid: 0, mode: 0o100755}, true},
+		{"group-write 0775", fileHeader{uid: 0, gid: 0, mode: 0o100775}, true},
+		{"nonzero uid ok", fileHeader{uid: 1000, gid: 1000, mode: 0o100644}, true},
+		{"xattr ok", fileHeader{uid: 0, gid: 0, mode: 0o100644, xattrs: []gvariant.Xattr{{Name: []byte("user.x"), Value: []byte("y")}}}, true},
+		{"setuid", fileHeader{uid: 0, gid: 0, mode: 0o104755}, false},
+		{"world-write", fileHeader{uid: 0, gid: 0, mode: 0o100666}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateBareUserOnly("deadbeef", c.h)
+			if c.ok && err != nil {
+				t.Errorf("expected ok, got %v", err)
+			}
+			if !c.ok && err == nil {
+				t.Errorf("expected error, got nil")
+			}
+		})
+	}
+}

--- a/pkg/ostree/bspatch.go
+++ b/pkg/ostree/bspatch.go
@@ -1,0 +1,80 @@
+//go:build linux
+
+package ostree
+
+import "fmt"
+
+// bspatchApply applies a bsdiff patch to old, writing exactly len(out) bytes.
+// It implements the mendsley/bsdiff control format that libostree bundles: the
+// patch is a stream of records [ctrl[0..2] each a 8-byte signed offtin int]
+// followed by ctrl[0] diff bytes and ctrl[1] extra bytes. ostree feeds the raw
+// patch bytes directly (no secondary bzip2 compression at this layer), matching
+// its bspatch_read callback that copies sequentially from the data-source.
+func bspatchApply(old, out, patch []byte) error {
+	var oldpos, newpos int64
+	oldsize := int64(len(old))
+	newsize := int64(len(out))
+	p := 0
+
+	read := func(n int64) ([]byte, error) {
+		if n < 0 || p+int(n) > len(patch) {
+			return nil, fmt.Errorf("patch truncated")
+		}
+		b := patch[p : p+int(n)]
+		p += int(n)
+		return b, nil
+	}
+
+	for newpos < newsize {
+		var ctrl [3]int64
+		for i := 0; i < 3; i++ {
+			b, err := read(8)
+			if err != nil {
+				return err
+			}
+			ctrl[i] = offtin(b)
+		}
+		if ctrl[0] < 0 || ctrl[1] < 0 || newpos+ctrl[0] > newsize {
+			return fmt.Errorf("invalid control triple")
+		}
+
+		// Diff string: copy ctrl[0] bytes from patch, add overlapping old bytes.
+		diff, err := read(ctrl[0])
+		if err != nil {
+			return err
+		}
+		copy(out[newpos:newpos+ctrl[0]], diff)
+		for i := int64(0); i < ctrl[0]; i++ {
+			if oldpos+i >= 0 && oldpos+i < oldsize {
+				out[newpos+i] += old[oldpos+i]
+			}
+		}
+		newpos += ctrl[0]
+		oldpos += ctrl[0]
+
+		if newpos+ctrl[1] > newsize {
+			return fmt.Errorf("extra string exceeds output")
+		}
+		// Extra string: copy ctrl[1] bytes verbatim from patch.
+		extra, err := read(ctrl[1])
+		if err != nil {
+			return err
+		}
+		copy(out[newpos:newpos+ctrl[1]], extra)
+		newpos += ctrl[1]
+		oldpos += ctrl[2]
+	}
+	return nil
+}
+
+// offtin decodes bsdiff's sign-magnitude 8-byte little-endian integer.
+func offtin(b []byte) int64 {
+	y := int64(b[7] & 0x7f)
+	for i := 6; i >= 0; i-- {
+		y = y*256 + int64(b[i])
+	}
+	if b[7]&0x80 != 0 {
+		y = -y
+	}
+	return y
+}

--- a/pkg/ostree/delta.go
+++ b/pkg/ostree/delta.go
@@ -1,0 +1,146 @@
+package ostree
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/foundriesio/ostreeuploader/pkg/gvariant"
+)
+
+// ErrNoDelta reports that the remote publishes no static delta for the requested
+// from->to pair, so the caller should fall back (to a full pull, or to a
+// different size estimate). It is distinct from a transport/parse failure.
+var ErrNoDelta = errors.New("no static delta for commit pair")
+
+// superblockFormat is the GVariant type of a static-delta superblock, pinned to
+// libostree 2024.5 (OSTREE_STATIC_DELTA_SUPERBLOCK_FORMAT in
+// ostree-repo-static-delta-private.h, with OSTREE_COMMIT_GVARIANT_STRING and the
+// meta-entry / fallback formats expanded):
+//
+//	(a{sv} t ay ay <commit> ay a(uayttay) a(yaytt))
+//
+// Top-level children:
+//
+//	0 a{sv}        metadata
+//	1 t            timestamp (big-endian)
+//	2 ay           from checksum
+//	3 ay           to checksum
+//	4 <commit>     new commit object
+//	5 ay           recursion (from,to) digests
+//	6 a(uayttay)   meta entries: (u version, ay csum, t size, t usize, ay objs)
+//	7 a(yaytt)     fallback: (y objtype, ay csum, t compressed, t uncompressed)
+//
+// The drift guard is delta_test.go, which cross-checks parsed totals against
+// `ostree static-delta show`.
+const superblockFormat = "(a{sv}tayay(a{sv}aya(say)sstayay)aya(uayttay)a(yaytt))"
+
+const (
+	sbMetaEntries = 6
+	sbFallback    = 7
+)
+
+// DeltaSize holds the storage figures for a static delta. They match what
+// `ostree static-delta show` reports as Total Size / Total Uncompressed Size.
+type DeltaSize struct {
+	// Compressed is the total download size (delta parts + fallback objects).
+	Compressed uint64 `json:"compressed"`
+	// Uncompressed is the total on-disk size of the objects the delta produces.
+	// This is the figure to compare against free space before applying an update.
+	Uncompressed uint64 `json:"uncompressed"`
+}
+
+// LocalDeltaSize reads the from->to static delta's size by parsing its
+// superblock directly from the local repository. The superblock must be present
+// (e.g. an offline update bundle); a missing delta yields an error. No `ostree`
+// process is involved.
+func (r *Repo) LocalDeltaSize(from, to string) (DeltaSize, error) {
+	dir, err := staticDeltaDir(from, to)
+	if err != nil {
+		return DeltaSize{}, err
+	}
+	path := filepath.Join(r.path, filepath.FromSlash(dir), "superblock")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return DeltaSize{}, fmt.Errorf("static delta %s..%s not found in repo", from, to)
+		}
+		return DeltaSize{}, fmt.Errorf("read superblock: %w", err)
+	}
+	return parseSuperblock(data)
+}
+
+// RemoteDeltaSize reads the from->to static delta's size from a remote repo by
+// fetching only its superblock (not the delta parts) and parsing it. This is the
+// online counterpart to LocalDeltaSize: it lets a caller estimate an update's
+// required storage before committing to the download, without the delta needing
+// to be present locally.
+//
+// It returns ErrNoDelta (wrapped) when the remote publishes no delta for the
+// pair (the superblock 404s / is absent), so callers can distinguish "no delta"
+// from a real transport or parse error.
+func RemoteDeltaSize(ctx context.Context, rc RemoteConfig, from, to string) (DeltaSize, error) {
+	dir, err := staticDeltaDir(from, to)
+	if err != nil {
+		return DeltaSize{}, err
+	}
+	t, err := newTransport(rc)
+	if err != nil {
+		return DeltaSize{}, err
+	}
+	sbRel := path.Join(dir, "superblock")
+	sbReader, _, err := t.open(ctx, sbRel, 0)
+	if err != nil {
+		if isNotFound(err) {
+			return DeltaSize{}, fmt.Errorf("%w: %s..%s", ErrNoDelta, from, to)
+		}
+		return DeltaSize{}, fmt.Errorf("fetch delta superblock: %w", err)
+	}
+	defer sbReader.Close()
+	data, err := io.ReadAll(sbReader)
+	if err != nil {
+		return DeltaSize{}, fmt.Errorf("read delta superblock: %w", err)
+	}
+	return parseSuperblock(data)
+}
+
+// newSuperblock wraps a static-delta superblock blob as a GVariant.
+func newSuperblock(data []byte) (*gvariant.Value, error) {
+	return gvariant.New(data, superblockFormat)
+}
+
+// parseSuperblock sums the meta-entry and fallback sizes from a superblock blob,
+// the same way `ostree static-delta show` computes its totals.
+func parseSuperblock(data []byte) (DeltaSize, error) {
+	sb, err := gvariant.New(data, superblockFormat)
+	if err != nil {
+		return DeltaSize{}, err
+	}
+
+	var ds DeltaSize
+
+	// Meta entries: (u version, ay csum, t size, t usize, ay objects).
+	meta := sb.Child(sbMetaEntries)
+	for i := 0; i < meta.Len(); i++ {
+		e := meta.At(i)
+		ds.Compressed += e.Child(2).Uint64()
+		ds.Uncompressed += e.Child(3).Uint64()
+	}
+
+	// Fallback objects: (y objtype, ay csum, t compressed, t uncompressed).
+	fb := sb.Child(sbFallback)
+	for i := 0; i < fb.Len(); i++ {
+		e := fb.At(i)
+		ds.Compressed += e.Child(2).Uint64()
+		ds.Uncompressed += e.Child(3).Uint64()
+	}
+
+	if err := sb.Err(); err != nil {
+		return DeltaSize{}, fmt.Errorf("parse superblock: %w", err)
+	}
+	return ds, nil
+}

--- a/pkg/ostree/delta_apply.go
+++ b/pkg/ostree/delta_apply.go
@@ -1,0 +1,179 @@
+//go:build linux
+
+package ostree
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/foundriesio/ostreeuploader/pkg/gvariant"
+	"github.com/ulikunitz/xz"
+)
+
+// Static-delta operation opcodes (libostree OSTREE_STATIC_DELTA_OP_*, ASCII).
+const (
+	opOpenSpliceAndClose = 'S' // 0x53
+	opOpen               = 'o' // 0x6f
+	opWrite              = 'w' // 0x77
+	opSetReadSource      = 'r' // 0x72
+	opUnsetReadSource    = 'R' // 0x52
+	opClose              = 'c' // 0x63
+	opBspatch            = 'B' // 0x42
+)
+
+// ostree object types (ostree-core.h). Meta types are 2..6.
+const (
+	objFile       = 1
+	objDirTree    = 2
+	objDirMeta    = 3
+	objCommit     = 4
+	objCommitMeta = 6
+)
+
+const objCsumLen = 33 // 1 byte objtype + 32 byte sha256
+
+// partPayloadFormat is the GVariant type of a (decompressed) static-delta part
+// payload (OSTREE_STATIC_DELTA_PART_PAYLOAD_FORMAT_V0):
+// (modes a(uuu), xattrs aa(ayay), data-source ay, operations ay).
+const partPayloadFormat = "(a(uuu)aa(ayay)ayay)"
+
+// deltaObject is one (objtype, hex-checksum) record from a meta entry's object
+// list, identifying an object the part produces (consumed in order).
+type deltaObject struct {
+	objType byte
+	csum    string
+}
+
+// deltaPart is a decoded static-delta part payload.
+type deltaPart struct {
+	modes  [][3]uint32 // (uid, gid, mode) triples, host order (already BE-decoded)
+	xattrs []*gvariant.Value
+	data   []byte // data-source blob
+	ops    []byte // operation bytecode
+}
+
+// applyStaticDelta applies the from->to static delta present in the local repo
+// (superblock + part files) by interpreting each part's operations, writing the
+// produced objects via the repo's bare-user(-only) writer. The commit and all
+// objects it references end up present and verified.
+func (r *Repo) applyStaticDelta(from, to string) error {
+	dir, err := staticDeltaDir(from, to)
+	if err != nil {
+		return err
+	}
+	base := filepath.Join(r.path, filepath.FromSlash(dir))
+	sbData, err := os.ReadFile(filepath.Join(base, "superblock"))
+	if err != nil {
+		return fmt.Errorf("read superblock: %w", err)
+	}
+	sb, err := newSuperblock(sbData)
+	if err != nil {
+		return err
+	}
+	meta := sb.Child(sbMetaEntries)
+	n := meta.Len()
+	for i := 0; i < n; i++ {
+		entry := meta.At(i)
+		wantCsum := hex.EncodeToString(entry.Child(1).Bytes())
+		objs, err := parseObjectList(entry.Child(4).Bytes())
+		if err != nil {
+			return fmt.Errorf("delta part %d: %w", i, err)
+		}
+		partRaw, err := os.ReadFile(filepath.Join(base, fmt.Sprintf("%d", i)))
+		if err != nil {
+			return fmt.Errorf("read delta part %d: %w", i, err)
+		}
+		// The meta entry's checksum is the SHA-256 of the whole raw part file.
+		if got := hex.EncodeToString(sha256Sum(partRaw)); got != wantCsum {
+			return fmt.Errorf("delta part %d: checksum mismatch (got %s want %s)", i, got, wantCsum)
+		}
+		part, err := decodePart(partRaw)
+		if err != nil {
+			return fmt.Errorf("delta part %d: %w", i, err)
+		}
+		if err := r.execDeltaPart(part, objs); err != nil {
+			return fmt.Errorf("delta part %d: %w", i, err)
+		}
+	}
+	if err := sb.Err(); err != nil {
+		return fmt.Errorf("superblock: %w", err)
+	}
+	return nil
+}
+
+// parseObjectList splits a meta entry's trailing flat byte array into
+// (objtype, checksum) records.
+func parseObjectList(raw []byte) ([]deltaObject, error) {
+	if len(raw)%objCsumLen != 0 {
+		return nil, fmt.Errorf("object list length %d not a multiple of %d", len(raw), objCsumLen)
+	}
+	out := make([]deltaObject, 0, len(raw)/objCsumLen)
+	for off := 0; off < len(raw); off += objCsumLen {
+		out = append(out, deltaObject{
+			objType: raw[off],
+			csum:    hex.EncodeToString(raw[off+1 : off+objCsumLen]),
+		})
+	}
+	return out, nil
+}
+
+// decodePart strips the leading compression byte, decompresses (XZ for 'x'),
+// and parses the part payload GVariant.
+func decodePart(raw []byte) (*deltaPart, error) {
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("empty part")
+	}
+	comp := raw[0]
+	body := raw[1:]
+	switch comp {
+	case 0:
+		// uncompressed; GVariant follows directly
+	case 'x':
+		xr, err := xz.NewReader(bytes.NewReader(body))
+		if err != nil {
+			return nil, fmt.Errorf("xz: %w", err)
+		}
+		body, err = io.ReadAll(xr)
+		if err != nil {
+			return nil, fmt.Errorf("xz decode: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported part compression %#x", comp)
+	}
+
+	pv, err := gvariant.New(body, partPayloadFormat)
+	if err != nil {
+		return nil, err
+	}
+	p := &deltaPart{
+		data: append([]byte(nil), pv.Child(2).Bytes()...),
+		ops:  append([]byte(nil), pv.Child(3).Bytes()...),
+	}
+	modes := pv.Child(0)
+	for i := 0; i < modes.Len(); i++ {
+		m := modes.At(i)
+		// The (uuu) ints are stored big-endian ("non-canonical"); the gvariant
+		// decoder returns them little-endian, so byte-swap.
+		p.modes = append(p.modes, [3]uint32{
+			swapU32(m.Child(0).Uint32()),
+			swapU32(m.Child(1).Uint32()),
+			swapU32(m.Child(2).Uint32()),
+		})
+	}
+	xa := pv.Child(1)
+	for i := 0; i < xa.Len(); i++ {
+		p.xattrs = append(p.xattrs, xa.At(i))
+	}
+	if err := pv.Err(); err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+func swapU32(x uint32) uint32 {
+	return (x>>24)&0xff | (x>>8)&0xff00 | (x<<8)&0xff0000 | (x<<24)&0xff000000
+}

--- a/pkg/ostree/delta_apply_test.go
+++ b/pkg/ostree/delta_apply_test.go
@@ -1,0 +1,172 @@
+//go:build linux
+
+package ostree
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// makeDeltaContentRepo builds an archive repo with two root-owned commits (so the
+// content is representable in bare-user-only) and a static delta between them,
+// returning (repoPath, fromCommit, toCommit). The content is structured and the
+// v2 change is a small in-place edit of a large file, which makes the delta
+// compiler emit rollsum (OPEN/WRITE/SET_READ_SOURCE/CLOSE) and bsdiff (BSPATCH)
+// operations in addition to whole-object splices (OPEN_SPLICE_AND_CLOSE) -- so
+// applying it exercises the full opcode set.
+func makeDeltaContentRepo(t *testing.T) (string, string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	repo := filepath.Join(dir, "repo")
+	tree := filepath.Join(dir, "tree")
+	mustMkdir(t, filepath.Join(tree, "usr", "bin"))
+	mustMkdir(t, filepath.Join(tree, "etc"))
+	run(t, "ostree", "--repo="+repo, "init", "--mode=archive")
+
+	// v1: a large, structured (compressible, self-similar) blob so the delta
+	// compiler finds rollsum/bsdiff matches against it.
+	prog := filepath.Join(tree, "usr", "bin", "prog")
+	writeStructured(t, prog, 4_000_000)
+	os.WriteFile(filepath.Join(tree, "etc", "version"), []byte("v1\n"), 0o644)
+	if err := os.Symlink("version", filepath.Join(tree, "etc", "current")); err != nil {
+		t.Fatal(err)
+	}
+	from := strings.TrimSpace(run(t, "ostree", "--repo="+repo, "commit", "--branch=main",
+		"--owner-uid=0", "--owner-gid=0", "--tree=dir="+tree))
+
+	// v2: flip a small middle region of the big file (head and tail stay
+	// identical -> rollsum match + bsdiff), and change a small file.
+	editMiddle(t, prog)
+	os.WriteFile(filepath.Join(tree, "etc", "version"), []byte("v2 updated\n"), 0o644)
+	to := strings.TrimSpace(run(t, "ostree", "--repo="+repo, "commit", "--branch=main",
+		"--owner-uid=0", "--owner-gid=0", "--tree=dir="+tree))
+
+	run(t, "ostree", "--repo="+repo, "static-delta", "generate", "--from="+from, "--to="+to)
+	return repo, from, to
+}
+
+// writeStructured writes n bytes of a deterministic, self-similar pattern.
+func writeStructured(t *testing.T, path string, n int) {
+	t.Helper()
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte((i*131 + 7) % 256)
+	}
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// editMiddle flips a small region in the middle of the file in place.
+func editMiddle(t *testing.T, path string) {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mid := len(b) / 2
+	for i := mid; i < mid+50 && i < len(b); i++ {
+		b[i]++
+	}
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustMkdir(t *testing.T, p string) {
+	t.Helper()
+	if err := os.MkdirAll(p, 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestApplyStaticDelta pulls the `from` commit fully, then applies the from->to
+// static delta with our pure-Go interpreter, and validates the result with
+// ostree fsck and a listing comparison against the source `to` commit.
+func TestApplyStaticDelta(t *testing.T) {
+	requireOstree(t)
+	srcRepo, from, to := makeDeltaContentRepo(t)
+	srv := httptest.NewServer(http.FileServer(http.Dir(srcRepo)))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "dest")
+	r := OpenRepo(dest).WithMode(modeBareUserOnly)
+
+	// 1. Populate the `from` commit (full object pull) so read-source ops resolve.
+	if _, err := r.Pull(context.Background(), PullOptions{Remote: RemoteConfig{BaseURL: srv.URL}, Commit: from}); err != nil {
+		t.Fatalf("pull from: %v", err)
+	}
+
+	// 2. Fetch the commit metadata for `to` (the delta produces content/dirtree/
+	// dirmeta but the commit object itself must be present for fsck/deploy).
+	f := &fetcher{t: mustTransport(t, srv.URL), repo: r}
+	if err := f.fetchMetadata(context.Background(), to, "commit"); err != nil {
+		t.Fatalf("fetch to commit: %v", err)
+	}
+
+	// 3. Copy the delta dir into the dest repo (apply reads it locally), then
+	// apply it.
+	copyDeltaDir(t, srcRepo, dest, from, to)
+	if err := r.markCommitPartial(to, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.applyStaticDelta(from, to); err != nil {
+		t.Fatalf("applyStaticDelta: %v", err)
+	}
+	if err := r.markCommitPartial(to, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.writeRef("main", to); err != nil {
+		t.Fatal(err)
+	}
+
+	// 4. Validate.
+	out := run(t, "ostree", "--repo="+dest, "fsck")
+	if !strings.Contains(out, "no errors found") {
+		t.Errorf("fsck failed:\n%s", out)
+	}
+	srcLs := run(t, "ostree", "--repo="+srcRepo, "ls", "-R", to)
+	dstLs := run(t, "ostree", "--repo="+dest, "ls", "-R", to)
+	if srcLs != dstLs {
+		t.Errorf("listings differ:\n--- src ---\n%s\n--- dst ---\n%s", srcLs, dstLs)
+	}
+}
+
+func mustTransport(t *testing.T, url string) transport {
+	t.Helper()
+	tr, err := newTransport(RemoteConfig{BaseURL: url})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tr
+}
+
+// copyDeltaDir copies the from->to static delta directory from src to dest repo.
+func copyDeltaDir(t *testing.T, srcRepo, destRepo, from, to string) {
+	t.Helper()
+	rel, err := staticDeltaDir(from, to)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srcDir := filepath.Join(srcRepo, filepath.FromSlash(rel))
+	dstDir := filepath.Join(destRepo, filepath.FromSlash(rel))
+	mustMkdir(t, dstDir)
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		b, err := os.ReadFile(filepath.Join(srcDir, e.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dstDir, e.Name()), b, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/pkg/ostree/delta_exec.go
+++ b/pkg/ostree/delta_exec.go
@@ -1,0 +1,329 @@
+//go:build linux
+
+package ostree
+
+import (
+	"encoding/hex"
+	"fmt"
+	"os"
+
+	"github.com/foundriesio/ostreeuploader/pkg/varint"
+)
+
+// deltaState is the interpreter state for one delta part, mirroring libostree's
+// StaticDeltaExecutionState (ostree-repo-static-delta-processing.c).
+type deltaState struct {
+	repo *Repo
+	part *deltaPart
+	objs []deltaObject
+
+	objIndex int // index into objs; advanced by CLOSE
+
+	// current open object
+	outType byte
+	outCsum string
+	hdr     fileHeader // for content objects (from modes/xattrs)
+	content []byte     // accumulated content for the open content object
+	size    uint64     // declared content size
+
+	// read source (the "from" object to copy/patch bytes out of)
+	readSrc []byte
+}
+
+// execDeltaPart runs the operation bytecode of a part against the repo.
+func (r *Repo) execDeltaPart(part *deltaPart, objs []deltaObject) error {
+	st := &deltaState{repo: r, part: part, objs: objs}
+	ops := part.ops
+	for len(ops) > 0 {
+		op := ops[0]
+		ops = ops[1:]
+		var err error
+		switch op {
+		case opOpenSpliceAndClose:
+			ops, err = st.openSpliceAndClose(ops)
+		case opOpen:
+			ops, err = st.open(ops)
+		case opWrite:
+			ops, err = st.write(ops)
+		case opSetReadSource:
+			ops, err = st.setReadSource(ops)
+		case opUnsetReadSource:
+			st.readSrc = nil
+		case opClose:
+			err = st.close()
+		case opBspatch:
+			ops, err = st.bspatch(ops)
+		default:
+			return fmt.Errorf("unknown delta opcode %#x", op)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// readVarint consumes one LEB128 varint from the head of ops.
+func readVarint(ops []byte) (uint64, []byte, error) {
+	v, n, err := varint.Uvarint(ops)
+	if err != nil {
+		return 0, ops, err
+	}
+	return v, ops[n:], nil
+}
+
+// nextObject selects the object the current open op produces (objs[objIndex]).
+func (st *deltaState) nextObject() error {
+	if st.objIndex >= len(st.objs) {
+		return fmt.Errorf("delta references more objects than declared (%d)", len(st.objs))
+	}
+	o := st.objs[st.objIndex]
+	st.outType = o.objType
+	st.outCsum = o.csum
+	st.content = nil
+	st.size = 0
+	return nil
+}
+
+// validateOfs bounds-checks an (offset,length) against the data-source blob.
+func (st *deltaState) validateOfs(offset, length uint64) error {
+	if offset > uint64(len(st.part.data)) || length > uint64(len(st.part.data))-offset {
+		return fmt.Errorf("delta op offset/length [%d,%d] out of data-source bounds %d", offset, length, len(st.part.data))
+	}
+	return nil
+}
+
+// contentOpen reads the mode/xattr offsets shared by content OPEN ops and sets
+// the header for the object being produced.
+func (st *deltaState) contentOpen(ops []byte) ([]byte, error) {
+	modeOff, ops, err := readVarint(ops)
+	if err != nil {
+		return ops, err
+	}
+	xattrOff, ops, err := readVarint(ops)
+	if err != nil {
+		return ops, err
+	}
+	if modeOff >= uint64(len(st.part.modes)) {
+		return ops, fmt.Errorf("mode offset %d out of range", modeOff)
+	}
+	m := st.part.modes[modeOff]
+	st.hdr = fileHeader{uid: m[0], gid: m[1], mode: m[2]}
+	if int(xattrOff) >= len(st.part.xattrs) {
+		// An empty xattr dict is common; only error if a non-empty index is bad.
+		if !(xattrOff == 0 && len(st.part.xattrs) == 0) {
+			return ops, fmt.Errorf("xattr offset %d out of range", xattrOff)
+		}
+	} else {
+		st.hdr.xattrs = parseXattrs(st.part.xattrs[xattrOff])
+	}
+	return ops, nil
+}
+
+// openSpliceAndClose ('S') writes a whole object in one operation.
+func (st *deltaState) openSpliceAndClose(ops []byte) ([]byte, error) {
+	if err := st.nextObject(); err != nil {
+		return ops, err
+	}
+	if isMetaObjType(st.outType) {
+		// metadata: length, offset into data-source -> write verbatim.
+		length, ops, err := readVarint(ops)
+		if err != nil {
+			return ops, err
+		}
+		offset, ops, err := readVarint(ops)
+		if err != nil {
+			return ops, err
+		}
+		if err := st.validateOfs(offset, length); err != nil {
+			return ops, err
+		}
+		raw := st.part.data[offset : offset+length]
+		if err := st.repo.writeMetadataObject(st.outCsum, metaExt(st.outType), raw); err != nil {
+			return ops, err
+		}
+		st.objIndex++
+		return ops, nil
+	}
+	// content: mode/xattr offsets, then content_size, content_offset.
+	ops, err := st.contentOpen(ops)
+	if err != nil {
+		return ops, err
+	}
+	size, ops, err := readVarint(ops)
+	if err != nil {
+		return ops, err
+	}
+	offset, ops, err := readVarint(ops)
+	if err != nil {
+		return ops, err
+	}
+	st.size = size
+	if st.hdr.isSymlink() {
+		// Symlink target lives in the data-source; content is empty.
+		if err := st.validateOfs(offset, size); err != nil {
+			return ops, err
+		}
+		st.hdr.symlink = string(st.part.data[offset : offset+size])
+	} else {
+		if err := st.validateOfs(offset, size); err != nil {
+			return ops, err
+		}
+		st.content = append([]byte(nil), st.part.data[offset:offset+size]...)
+	}
+	if err := st.commitContent(); err != nil {
+		return ops, err
+	}
+	st.objIndex++
+	return ops, nil
+}
+
+// open ('o') begins a content object that subsequent WRITE/BSPATCH ops fill.
+func (st *deltaState) open(ops []byte) ([]byte, error) {
+	if err := st.nextObject(); err != nil {
+		return ops, err
+	}
+	ops, err := st.contentOpen(ops)
+	if err != nil {
+		return ops, err
+	}
+	size, ops, err := readVarint(ops)
+	if err != nil {
+		return ops, err
+	}
+	st.size = size
+	st.content = make([]byte, 0, size)
+	return ops, nil
+}
+
+// write ('w') appends bytes from the read-source object or the data-source blob.
+func (st *deltaState) write(ops []byte) ([]byte, error) {
+	size, ops, err := readVarint(ops)
+	if err != nil {
+		return ops, err
+	}
+	offset, ops, err := readVarint(ops)
+	if err != nil {
+		return ops, err
+	}
+	if st.readSrc != nil {
+		if offset > uint64(len(st.readSrc)) || size > uint64(len(st.readSrc))-offset {
+			return ops, fmt.Errorf("write: read-source range [%d,%d] out of bounds %d", offset, size, len(st.readSrc))
+		}
+		st.content = append(st.content, st.readSrc[offset:offset+size]...)
+	} else {
+		if err := st.validateOfs(offset, size); err != nil {
+			return ops, err
+		}
+		st.content = append(st.content, st.part.data[offset:offset+size]...)
+	}
+	return ops, nil
+}
+
+// setReadSource ('r') loads an existing repo object's raw content as the copy
+// source. The 32-byte object checksum sits in the data-source at source_offset.
+func (st *deltaState) setReadSource(ops []byte) ([]byte, error) {
+	offset, ops, err := readVarint(ops)
+	if err != nil {
+		return ops, err
+	}
+	if err := st.validateOfs(offset, 32); err != nil {
+		return ops, err
+	}
+	csum := hex.EncodeToString(st.part.data[offset : offset+32])
+	content, err := st.repo.readContentObject(csum)
+	if err != nil {
+		return ops, fmt.Errorf("set-read-source %s: %w", csum, err)
+	}
+	st.readSrc = content
+	return ops, nil
+}
+
+// bspatch ('B') applies a bsdiff patch (from the data-source) to the read-source
+// content, producing st.size bytes appended to the open object.
+func (st *deltaState) bspatch(ops []byte) ([]byte, error) {
+	offset, ops, err := readVarint(ops)
+	if err != nil {
+		return ops, err
+	}
+	length, ops, err := readVarint(ops)
+	if err != nil {
+		return ops, err
+	}
+	if err := st.validateOfs(offset, length); err != nil {
+		return ops, err
+	}
+	if st.readSrc == nil {
+		return ops, fmt.Errorf("bspatch with no read source")
+	}
+	out := make([]byte, st.size)
+	if err := bspatchApply(st.readSrc, out, st.part.data[offset:offset+length]); err != nil {
+		return ops, fmt.Errorf("bspatch: %w", err)
+	}
+	st.content = append(st.content, out...)
+	return ops, nil
+}
+
+// close ('c') commits the open content object and advances the object index.
+func (st *deltaState) close() error {
+	if err := st.commitContent(); err != nil {
+		return err
+	}
+	st.readSrc = nil
+	st.objIndex++
+	return nil
+}
+
+// commitContent writes the currently-open content object via the repo writer,
+// which verifies its checksum against st.outCsum.
+func (st *deltaState) commitContent() error {
+	if st.outType != objFile {
+		return fmt.Errorf("commit content: object %s is not a file object", st.outCsum)
+	}
+	return st.repo.writeContentObject(st.outCsum, st.hdr, st.content)
+}
+
+func isMetaObjType(t byte) bool { return t >= 2 && t <= 6 }
+func metaExt(t byte) string {
+	switch t {
+	case objDirTree:
+		return "dirtree"
+	case objDirMeta:
+		return "dirmeta"
+	case objCommit:
+		return "commit"
+	case objCommitMeta:
+		return "commitmeta"
+	default:
+		return fmt.Sprintf("objtype%d", t)
+	}
+}
+
+// readContentObject reconstructs the raw (uncompressed) content of a content
+// object already present in the repo, for use as a delta read-source.
+func (r *Repo) readContentObject(csum string) ([]byte, error) {
+	path := r.objectPath(csum, "file")
+	if r.repoMode() == modeBareUserOnly {
+		// The .file body IS the raw content (regular file) or, for a symlink,
+		// the link target (no trailing NUL on disk).
+		fi, err := os.Lstat(path)
+		if err != nil {
+			return nil, err
+		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			target, err := os.Readlink(path)
+			if err != nil {
+				return nil, err
+			}
+			return []byte(target), nil
+		}
+		return os.ReadFile(path)
+	}
+	// bare-user: the .file body is the raw content (regular) or target+NUL
+	// (symlink). Strip the trailing NUL for symlinks.
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
+}

--- a/pkg/ostree/delta_remote_test.go
+++ b/pkg/ostree/delta_remote_test.go
@@ -1,0 +1,54 @@
+//go:build linux
+
+package ostree
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestRemoteDeltaSize serves a real delta repo over HTTP and asserts that
+// RemoteDeltaSize (which fetches only the superblock) returns the same figures
+// as LocalDeltaSize over the same repo on disk — i.e. an online estimate needs
+// no local delta and matches `ostree static-delta show`.
+func TestRemoteDeltaSize(t *testing.T) {
+	requireOstree(t)
+	repo, from, to := makeDeltaRepo(t)
+
+	srv := httptest.NewServer(http.FileServer(http.Dir(repo)))
+	defer srv.Close()
+
+	local, err := OpenRepo(repo).LocalDeltaSize(from, to)
+	if err != nil {
+		t.Fatalf("local delta size: %v", err)
+	}
+	remote, err := RemoteDeltaSize(context.Background(), RemoteConfig{BaseURL: srv.URL}, from, to)
+	if err != nil {
+		t.Fatalf("remote delta size: %v", err)
+	}
+	if remote != local {
+		t.Errorf("remote %+v != local %+v", remote, local)
+	}
+	if remote.Uncompressed == 0 {
+		t.Errorf("expected non-zero uncompressed size, got %+v", remote)
+	}
+}
+
+// TestRemoteDeltaSizeNoDelta confirms that when the remote publishes no delta
+// for the pair, RemoteDeltaSize reports ErrNoDelta (not a generic error), so the
+// caller can fall back rather than treat it as a failure.
+func TestRemoteDeltaSizeNoDelta(t *testing.T) {
+	requireOstree(t)
+	repo, _, to := makeDeltaRepo(t)
+	srv := httptest.NewServer(http.FileServer(http.Dir(repo)))
+	defer srv.Close()
+
+	const absentFrom = "0000000000000000000000000000000000000000000000000000000000000000"
+	_, err := RemoteDeltaSize(context.Background(), RemoteConfig{BaseURL: srv.URL}, absentFrom, to)
+	if !errors.Is(err, ErrNoDelta) {
+		t.Fatalf("expected ErrNoDelta, got %v", err)
+	}
+}

--- a/pkg/ostree/delta_test.go
+++ b/pkg/ostree/delta_test.go
@@ -1,0 +1,165 @@
+//go:build linux
+
+package ostree
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// requireOstree skips the test if the ostree CLI isn't available. ostree is used
+// ONLY as the test oracle here, never by the library.
+func requireOstree(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("ostree"); err != nil {
+		t.Skip("ostree CLI not found; skipping integration test")
+	}
+}
+
+func run(t *testing.T, name string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %s failed: %v\n%s", name, strings.Join(args, " "), err, out)
+	}
+	return string(out)
+}
+
+// makeDeltaRepo builds a scratch archive repo with two commits and a static
+// delta between them, returning (repoPath, fromCommit, toCommit).
+func makeDeltaRepo(t *testing.T) (string, string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	repo := filepath.Join(dir, "repo")
+	tree := filepath.Join(dir, "tree")
+	if err := os.MkdirAll(filepath.Join(tree, "usr", "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(tree, "etc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	run(t, "ostree", "--repo="+repo, "init", "--mode=archive")
+
+	// v1
+	writeRandom(t, filepath.Join(tree, "usr", "bin", "blob1"), 2_000_000)
+	os.WriteFile(filepath.Join(tree, "etc", "version"), []byte("v1\n"), 0o644)
+	from := strings.TrimSpace(run(t, "ostree", "--repo="+repo, "commit", "--branch=test", "--tree=dir="+tree))
+
+	// v2
+	writeRandom(t, filepath.Join(tree, "usr", "bin", "blob2"), 3_000_000)
+	os.WriteFile(filepath.Join(tree, "etc", "version"), []byte("v2 updated\n"), 0o644)
+	to := strings.TrimSpace(run(t, "ostree", "--repo="+repo, "commit", "--branch=test", "--tree=dir="+tree))
+
+	run(t, "ostree", "--repo="+repo, "static-delta", "generate", "--from="+from, "--to="+to)
+	return repo, from, to
+}
+
+func writeRandom(t *testing.T, path string, n int) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	buf := make([]byte, n)
+	src, err := os.Open("/dev/urandom")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer src.Close()
+	if _, err := src.Read(buf); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write(buf); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestDeltaSizeMatchesOstreeShow is the ground-truth guard: our superblock-parsed
+// totals must equal the numbers `ostree static-delta show` prints. This both
+// validates the pure-Go GVariant parsing and pins the on-disk format contract.
+func TestDeltaSizeMatchesOstreeShow(t *testing.T) {
+	requireOstree(t)
+	repo, from, to := makeDeltaRepo(t)
+
+	show := run(t, "ostree", "--repo="+repo, "static-delta", "show", from+"-"+to)
+	wantSize := mustMatch(t, regexp.MustCompile(`(?m)^Total Size:\s+(\d+)`), show)
+	wantUSize := mustMatch(t, regexp.MustCompile(`(?m)^Total Uncompressed Size:\s+(\d+)`), show)
+
+	r := OpenRepo(repo)
+	ds, err := r.LocalDeltaSize(from, to)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ds.Compressed != wantSize {
+		t.Errorf("compressed size: got %d, ostree says %d", ds.Compressed, wantSize)
+	}
+	if ds.Uncompressed != wantUSize {
+		t.Errorf("uncompressed size: got %d, ostree says %d", ds.Uncompressed, wantUSize)
+	}
+}
+
+func mustMatch(t *testing.T, re *regexp.Regexp, s string) uint64 {
+	t.Helper()
+	m := re.FindStringSubmatch(s)
+	if m == nil {
+		t.Fatalf("pattern %q not found in:\n%s", re, s)
+	}
+	v, err := strconv.ParseUint(m[1], 10, 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return v
+}
+
+// TestMissingDeltaErrors confirms a clean error when the delta is absent.
+func TestMissingDeltaErrors(t *testing.T) {
+	requireOstree(t)
+	repo, _, _ := makeDeltaRepo(t)
+	r := OpenRepo(repo)
+	const a = "b7e6ee540547970b5fa75133f2348587929e74f03eb1132486759d4e473bdc8d"
+	const b = "d284210256995ad1d1ac1cb9fbba95968b64c80b508c4bb32881a3d2c83525d5"
+	if _, err := r.LocalDeltaSize(a, b); err == nil {
+		t.Fatal("expected error for missing delta")
+	}
+}
+
+// TestEstimateInsufficient checks the watermark gate fires when reserved space
+// exceeds free space.
+func TestEstimateInsufficient(t *testing.T) {
+	requireOstree(t)
+	repo, from, to := makeDeltaRepo(t)
+	r := OpenRepo(repo)
+
+	// Reserve an absurd amount so Available collapses to 0.
+	_, err := r.EstimateLocalUpdate(from, to, repo, 1<<62, true)
+	if err == nil {
+		t.Fatal("expected insufficient storage error")
+	}
+	var ise *InsufficientStorageError
+	if !asInsufficient(err, &ise) {
+		t.Fatalf("expected InsufficientStorageError, got %T: %v", err, err)
+	}
+}
+
+func asInsufficient(err error, target **InsufficientStorageError) bool {
+	for err != nil {
+		if e, ok := err.(*InsufficientStorageError); ok {
+			*target = e
+			return true
+		}
+		type unwrapper interface{ Unwrap() error }
+		u, ok := err.(unwrapper)
+		if !ok {
+			return false
+		}
+		err = u.Unwrap()
+	}
+	return false
+}

--- a/pkg/ostree/errors.go
+++ b/pkg/ostree/errors.go
@@ -1,0 +1,43 @@
+//go:build linux
+
+package ostree
+
+import (
+	"errors"
+	"fmt"
+	"syscall"
+)
+
+// ErrInsufficientStorage is returned (wrapped) when the estimated required space
+// for an update exceeds the available space after applying the reserved
+// watermark. It mirrors aktualizr-lite's DownloadFailed_NoSpace and fioup's
+// InsufficientStorageError.
+var ErrInsufficientStorage = errors.New("insufficient storage for update")
+
+// InsufficientStorageError carries the usage figures alongside the sentinel.
+type InsufficientStorageError struct {
+	Usage *UsageInfo
+}
+
+func (e *InsufficientStorageError) Error() string {
+	u := e.Usage
+	return fmt.Sprintf("%s: required %s, available %s; size %s, free %s, reserved %s",
+		ErrInsufficientStorage.Error(),
+		FormatBytes(u.Required), FormatBytes(u.Available),
+		FormatBytes(u.SizeB), FormatBytes(u.Free), FormatBytes(u.Reserved))
+}
+
+func (e *InsufficientStorageError) Unwrap() error { return ErrInsufficientStorage }
+
+// wrapENOSPC converts any error caused by ENOSPC into an ErrInsufficientStorage
+// so the caller can errors.Is(err, ErrInsufficientStorage) without knowing
+// whether the failure came from a pre-flight check or a mid-pull write.
+func wrapENOSPC(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, syscall.ENOSPC) {
+		return fmt.Errorf("%w: %w", ErrInsufficientStorage, err)
+	}
+	return err
+}

--- a/pkg/ostree/estimate.go
+++ b/pkg/ostree/estimate.go
@@ -1,0 +1,59 @@
+//go:build linux
+
+package ostree
+
+import "fmt"
+
+// Estimate is the full result of a pre-flight update size check.
+type Estimate struct {
+	From  string     `json:"from"`
+	To    string     `json:"to"`
+	Delta DeltaSize  `json:"delta"`
+	Usage *UsageInfo `json:"usage"`
+	// Sufficient is true when Usage.Available >= Usage.Required.
+	Sufficient bool `json:"sufficient"`
+}
+
+// EstimateFromDeltaSize builds an Estimate from an already-obtained DeltaSize by
+// querying free space at checkPath against the watermark. When there is not
+// enough room, it returns the Estimate alongside an *InsufficientStorageError
+// (which wraps ErrInsufficientStorage).
+func EstimateFromDeltaSize(from, to, checkPath string, ds DeltaSize, watermark uint64, watermarkInBytes bool) (*Estimate, error) {
+	ui, err := GetUsageInfo(checkPath, ds.Uncompressed, watermark, watermarkInBytes)
+	if err != nil {
+		return nil, fmt.Errorf("usage info: %w", err)
+	}
+	est := &Estimate{
+		From:       from,
+		To:         to,
+		Delta:      ds,
+		Usage:      ui,
+		Sufficient: ui.Available >= ui.Required,
+	}
+	if !est.Sufficient {
+		return est, &InsufficientStorageError{Usage: ui}
+	}
+	return est, nil
+}
+
+// EstimateLocalUpdate computes the storage a from->to ostree update will require,
+// reading the delta size from the local repository's superblock (pure Go, no
+// `ostree` process), and compares it against the available space at checkPath
+// (after the reserved watermark).
+//
+// watermark is a percentage of total size (e.g. 95) when watermarkInBytes is
+// false, or an absolute reserved byte count when watermarkInBytes is true.
+//
+// The returned *Estimate always reflects the computed figures. When there is not
+// enough room, the error is an *InsufficientStorageError that also wraps
+// ErrInsufficientStorage.
+func (r *Repo) EstimateLocalUpdate(from, to, checkPath string, watermark uint64, watermarkInBytes bool) (*Estimate, error) {
+	ds, err := r.LocalDeltaSize(from, to)
+	if err != nil {
+		return nil, fmt.Errorf("delta size: %w", err)
+	}
+	if checkPath == "" {
+		checkPath = r.path
+	}
+	return EstimateFromDeltaSize(from, to, checkPath, ds, watermark, watermarkInBytes)
+}

--- a/pkg/ostree/fetch.go
+++ b/pkg/ostree/fetch.go
@@ -1,0 +1,142 @@
+package ostree
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// RemoteConfig describes where and how to fetch objects from. BaseURL may be an
+// http(s):// or file:// URL.
+//
+// fiopull is intentionally Device-Gateway-agnostic: it fetches from a plain
+// HTTP(s) server (e.g. a signed object-store / GCS URL) and does not speak the
+// gateway's download-urls protocol or use device mTLS credentials. Any auth is
+// carried by the caller through the URL itself (a signed URL) or via Headers
+// (e.g. "Authorization: Bearer ..."). Headers are sent on every request.
+type RemoteConfig struct {
+	BaseURL string
+	Headers map[string]string
+}
+
+// transport abstracts fetching a repo-relative path, so http:// and file://
+// share the pull logic.
+type transport interface {
+	// open returns a reader for relPath starting at byte offset (0 = whole
+	// object). resumed reports whether the server honored the offset (so the
+	// caller should append rather than truncate). A nil error with resumed=false
+	// and offset>0 means the server ignored Range and is sending from the start.
+	open(ctx context.Context, relPath string, offset int64) (rc io.ReadCloser, resumed bool, err error)
+}
+
+// newTransport builds a transport for the remote's BaseURL.
+func newTransport(rc RemoteConfig) (transport, error) {
+	u, err := url.Parse(rc.BaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("bad remote URL %q: %w", rc.BaseURL, err)
+	}
+	switch u.Scheme {
+	case "file", "":
+		return &fileTransport{root: u.Path}, nil
+	case "http", "https":
+		base := strings.TrimRight(rc.BaseURL, "/")
+		return &httpTransport{client: &http.Client{}, base: base, headers: rc.Headers}, nil
+	default:
+		return nil, fmt.Errorf("unsupported remote scheme %q", u.Scheme)
+	}
+}
+
+// --- HTTP transport ---
+
+type httpTransport struct {
+	client  *http.Client
+	base    string
+	headers map[string]string
+}
+
+func (t *httpTransport) open(ctx context.Context, relPath string, offset int64) (io.ReadCloser, bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, t.base+"/"+relPath, nil)
+	if err != nil {
+		return nil, false, err
+	}
+	req.Header.Set("Content-Type", "application/octet-stream")
+	for k, v := range t.headers {
+		req.Header.Set(k, v)
+	}
+	if offset > 0 {
+		req.Header.Set("Range", fmt.Sprintf("bytes=%d-", offset))
+	}
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return nil, false, err
+	}
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// Whole object (server ignored Range if we sent one).
+		return resp.Body, false, nil
+	case http.StatusPartialContent:
+		return resp.Body, true, nil
+	default:
+		resp.Body.Close()
+		return nil, false, &httpError{path: relPath, status: resp.StatusCode}
+	}
+}
+
+// httpError reports a non-success HTTP status for a fetched path.
+type httpError struct {
+	path   string
+	status int
+}
+
+func (e *httpError) Error() string {
+	return fmt.Sprintf("fetch %s: HTTP %d", e.path, e.status)
+}
+
+// isNotFound reports whether err indicates a missing object (HTTP 404 or a
+// missing file://), so callers can tolerate optional objects.
+func isNotFound(err error) bool {
+	if he, ok := err.(*httpError); ok {
+		return he.status == http.StatusNotFound
+	}
+	if _, ok := err.(*fileNotFound); ok {
+		return true
+	}
+	return false
+}
+
+// --- file:// transport ---
+
+type fileTransport struct{ root string }
+
+func (t *fileTransport) open(_ context.Context, relPath string, offset int64) (io.ReadCloser, bool, error) {
+	f, err := os.Open(filepath.Join(t.root, filepath.FromSlash(relPath)))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, false, &fileNotFound{relPath}
+		}
+		return nil, false, err
+	}
+	if offset > 0 {
+		if _, err := f.Seek(offset, io.SeekStart); err != nil {
+			f.Close()
+			return nil, false, err
+		}
+		return f, true, nil
+	}
+	return f, false, nil
+}
+
+type fileNotFound struct{ path string }
+
+func (e *fileNotFound) Error() string { return "not found: " + e.path }
+
+// objectRelPath returns the repo-relative URL path of a loose object.
+func objectRelPath(csum, ext string) string {
+	return path.Join("objects", csum[:2], csum[2:]+"."+ext)
+}

--- a/pkg/ostree/fetch_test.go
+++ b/pkg/ostree/fetch_test.go
@@ -1,0 +1,50 @@
+//go:build linux
+
+package ostree
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+)
+
+// TestTransportHeaders verifies per-request headers are sent on every GET.
+// Headers are fiopull's only auth mechanism (e.g. a bearer token supplied by
+// the caller); there is no built-in mTLS/gateway handling.
+func TestTransportHeaders(t *testing.T) {
+	var mu sync.Mutex
+	seen := map[string]string{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		seen["Authorization"] = r.Header.Get("Authorization")
+		seen["X-Correlation-ID"] = r.Header.Get("X-Correlation-ID")
+		mu.Unlock()
+		http.Error(w, "nf", http.StatusNotFound) // content doesn't matter
+	}))
+	defer srv.Close()
+
+	tr, err := newTransport(RemoteConfig{
+		BaseURL: srv.URL,
+		Headers: map[string]string{"Authorization": "Bearer tok123", "X-Correlation-ID": "corr-9"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rc, _, err := tr.open(context.Background(), "refs/heads/main", 0)
+	if rc != nil {
+		rc.Close()
+	}
+	if !isNotFound(err) {
+		t.Fatalf("expected 404, got %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if seen["Authorization"] != "Bearer tok123" {
+		t.Errorf("Authorization not sent: %q", seen["Authorization"])
+	}
+	if seen["X-Correlation-ID"] != "corr-9" {
+		t.Errorf("X-Correlation-ID not sent: %q", seen["X-Correlation-ID"])
+	}
+}

--- a/pkg/ostree/filez.go
+++ b/pkg/ostree/filez.go
@@ -1,0 +1,119 @@
+package ostree
+
+import (
+	"bytes"
+	"compress/flate"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"io"
+
+	"github.com/foundriesio/ostreeuploader/pkg/gvariant"
+)
+
+// zlibFileHeaderFormat is the GVariant type of the header embedded in an archive
+// .filez object: (size, uid, gid, mode, rdev, symlink-target, xattrs). The
+// leading 't' (uncompressed size) is dropped to form the checksum header. uid/
+// gid/mode/rdev are big-endian uint32. (libostree 2024.5,
+// _OSTREE_ZLIB_FILE_HEADER_GVARIANT_FORMAT.)
+const zlibFileHeaderFormat = "(tuuuusa(ayay))"
+
+// fileHeader is the metadata of a content object, parsed from a .filez header.
+type fileHeader struct {
+	uid, gid, mode uint32
+	symlink        string // symlink target, "" for regular files
+	xattrs         []gvariant.Xattr
+}
+
+// isSymlink reports whether the header describes a symlink (mode S_IFLNK).
+func (h fileHeader) isSymlink() bool { return h.mode&0o170000 == 0o120000 }
+
+// beU32 reads a big-endian uint32 from the first 4 bytes of b.
+func beU32(b []byte) uint32 {
+	if len(b) < 4 {
+		return 0
+	}
+	return binary.BigEndian.Uint32(b)
+}
+
+// parseFilez splits an archive .filez object into its header and uncompressed
+// content. Layout: [4B BE header_size][4B zero pad][header GVariant][raw-DEFLATE
+// content]. The content of a symlink is empty (its target lives in the header).
+func parseFilez(data []byte) (fileHeader, []byte, error) {
+	if len(data) < 8 {
+		return fileHeader{}, nil, fmt.Errorf("filez too short: %d bytes", len(data))
+	}
+	hdrSize := binary.BigEndian.Uint32(data[0:4])
+	// data[4:8] is 4 zero padding bytes.
+	end := 8 + uint64(hdrSize)
+	if end > uint64(len(data)) {
+		return fileHeader{}, nil, fmt.Errorf("filez header size %d exceeds object", hdrSize)
+	}
+	hv, err := gvariant.New(data[8:end], zlibFileHeaderFormat)
+	if err != nil {
+		return fileHeader{}, nil, fmt.Errorf("decode filez header: %w", err)
+	}
+	h := fileHeader{
+		uid:     beU32(hv.Child(1).Raw()),
+		gid:     beU32(hv.Child(2).Raw()),
+		mode:    beU32(hv.Child(3).Raw()),
+		symlink: hv.Child(5).Str(),
+		xattrs:  parseXattrs(hv.Child(6)),
+	}
+	if err := hv.Err(); err != nil {
+		return fileHeader{}, nil, fmt.Errorf("decode filez header: %w", err)
+	}
+
+	var content []byte
+	if !h.isSymlink() {
+		zr := flate.NewReader(bytes.NewReader(data[end:]))
+		content, err = io.ReadAll(zr)
+		zr.Close()
+		if err != nil {
+			return fileHeader{}, nil, fmt.Errorf("inflate filez content: %w", err)
+		}
+	}
+	return h, content, nil
+}
+
+// parseXattrs extracts an a(ayay) xattr array into gvariant.Xattr values. The
+// names retain no trailing NUL (it is re-added on encode).
+func parseXattrs(arr *gvariant.Value) []gvariant.Xattr {
+	n := arr.Len()
+	if n == 0 {
+		return nil
+	}
+	out := make([]gvariant.Xattr, 0, n)
+	for i := 0; i < n; i++ {
+		e := arr.At(i)
+		name := e.Child(0).Bytes()
+		// Stored names are NUL-terminated; strip it for the in-memory form.
+		if len(name) > 0 && name[len(name)-1] == 0 {
+			name = name[:len(name)-1]
+		}
+		out = append(out, gvariant.Xattr{
+			Name:  append([]byte(nil), name...),
+			Value: append([]byte(nil), e.Child(1).Bytes()...),
+		})
+	}
+	return out
+}
+
+// contentObjectID computes the 64-hex checksum (and thus object filename) of a
+// content object, the same way ostree does: sha256 over the length-prefixed
+// uncompressed header (uuuusa(ayay)) followed by the raw uncompressed content.
+// The length prefix is [4B BE variant_size][4B zero pad].
+func contentObjectID(h fileHeader, content []byte) string {
+	hdr := gvariant.EncodeFileHeader(h.uid, h.gid, h.mode, h.symlink, h.xattrs)
+
+	sum := sha256.New()
+	var prefix [8]byte
+	binary.BigEndian.PutUint32(prefix[0:4], uint32(len(hdr)))
+	sum.Write(prefix[:]) // 4B size + 4B zero padding
+	sum.Write(hdr)
+	if !h.isSymlink() {
+		sum.Write(content)
+	}
+	return hex.EncodeToString(sum.Sum(nil))
+}

--- a/pkg/ostree/filez_test.go
+++ b/pkg/ostree/filez_test.go
@@ -1,0 +1,96 @@
+//go:build linux
+
+package ostree
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestFilezParseAndChecksum parses real .filez objects from a scratch archive
+// repo and asserts our computed content-object id equals the object's filename
+// (i.e. our pure-Go checksum matches ostree's), and that the inflated content
+// matches what `ostree cat` returns.
+func TestFilezParseAndChecksum(t *testing.T) {
+	requireOstree(t)
+	repo, _, to := makeContentRepo(t)
+
+	// Walk the whole tree (files live in subdirs) and check every file object.
+	r := OpenRepo(repo)
+	var checked int
+	var walk func(tree string)
+	walk = func(tree string) {
+		entries, err := r.ReadDirTree(tree)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, e := range entries {
+			if e.IsDir {
+				walk(e.Checksum)
+				continue
+			}
+			fz := r.objectPath(e.Checksum, "filez")
+			data, err := os.ReadFile(fz)
+			if err != nil {
+				t.Fatalf("read %s: %v", fz, err)
+			}
+			hdr, content, err := parseFilez(data)
+			if err != nil {
+				t.Fatalf("parseFilez %s: %v", e.Name, err)
+			}
+			if got := contentObjectID(hdr, content); got != e.Checksum {
+				t.Errorf("%s: contentObjectID got %s want %s", e.Name, got, e.Checksum)
+			}
+			checked++
+		}
+	}
+	walk(mustRootTree(t, r, to))
+	if checked == 0 {
+		t.Fatal("no file objects checked")
+	}
+}
+
+func mustRootTree(t *testing.T, r *Repo, commit string) string {
+	t.Helper()
+	c, err := r.ReadCommit(commit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c.RootDirTree
+}
+
+// makeContentRepo builds a scratch archive repo with a regular file, a second
+// regular file in a subdir, and a symlink, returning (repoPath, ref, commit).
+func makeContentRepo(t *testing.T) (string, string, string) {
+	return makeContentRepoOpts(t, false)
+}
+
+// makeContentRepoOpts is makeContentRepo with an option to canonicalize file
+// ownership to uid/gid 0 (rootOwned), as published rootfs content is — required
+// for the content to be representable in a bare-user-only repo.
+func makeContentRepoOpts(t *testing.T, rootOwned bool) (string, string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	repo := filepath.Join(dir, "repo")
+	tree := filepath.Join(dir, "tree")
+	if err := os.MkdirAll(filepath.Join(tree, "usr", "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(tree, "etc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	run(t, "ostree", "--repo="+repo, "init", "--mode=archive")
+	writeRandom(t, filepath.Join(tree, "usr", "bin", "prog"), 1_500_000)
+	os.WriteFile(filepath.Join(tree, "etc", "version"), []byte("v1\n"), 0o644)
+	if err := os.Symlink("version", filepath.Join(tree, "etc", "current")); err != nil {
+		t.Fatal(err)
+	}
+	args := []string{"--repo=" + repo, "commit", "--branch=main", "--tree=dir=" + tree}
+	if rootOwned {
+		args = append(args, "--owner-uid=0", "--owner-gid=0")
+	}
+	to := strings.TrimSpace(run(t, "ostree", args...))
+	return repo, "main", to
+}

--- a/pkg/ostree/object.go
+++ b/pkg/ostree/object.go
@@ -1,0 +1,113 @@
+package ostree
+
+import (
+	"encoding/hex"
+	"fmt"
+	"os"
+
+	"github.com/foundriesio/ostreeuploader/pkg/gvariant"
+)
+
+// GVariant type strings for ostree objects, pinned to libostree 2024.5
+// (ostree-core.h). The drift guard is the integration test that cross-checks
+// these against a repo produced by the installed ostree.
+const (
+	// commitFormat: (metadata, parent-csum, related, subject, body,
+	//                timestamp, root-dirtree-csum, root-dirmeta-csum).
+	commitFormat = "(a{sv}aya(say)sstayay)"
+	// dirTreeFormat: (files=[(name, csum)], dirs=[(name, tree-csum, meta-csum)]).
+	dirTreeFormat = "(a(say)a(sayay))"
+)
+
+// Commit is the decoded content of an ostree commit object.
+type Commit struct {
+	Subject     string
+	Body        string
+	Timestamp   uint64 // seconds since epoch (big-endian in the object)
+	RootDirTree string // hex checksum of the root dirtree object
+	RootDirMeta string // hex checksum of the root dirmeta object
+}
+
+// DirEntry is a child of a directory: a file or a subdirectory.
+type DirEntry struct {
+	Name     string
+	Checksum string // file content / subdir dirtree checksum (hex)
+	MetaSum  string // subdir dirmeta checksum (hex); empty for files
+	IsDir    bool
+}
+
+// readObject reads and wraps the loose object <csum>.<ext> as a GVariant of the
+// given format.
+func (r *Repo) readObject(csum, ext, format string) (*gvariant.Value, error) {
+	data, err := os.ReadFile(r.objectPath(csum, ext))
+	if err != nil {
+		return nil, fmt.Errorf("read %s object %s: %w", ext, csum, err)
+	}
+	v, err := gvariant.New(data, format)
+	if err != nil {
+		return nil, fmt.Errorf("decode %s object %s: %w", ext, csum, err)
+	}
+	return v, nil
+}
+
+// ReadCommit reads and decodes the commit object identified by csum.
+func (r *Repo) ReadCommit(csum string) (*Commit, error) {
+	v, err := r.readObject(csum, "commit", commitFormat)
+	if err != nil {
+		return nil, err
+	}
+	return decodeCommit(csum, v)
+}
+
+// decodeCommit decodes a commit object already wrapped as a GVariant.
+func decodeCommit(csum string, v *gvariant.Value) (*Commit, error) {
+	c := &Commit{
+		Subject:     v.Child(3).Str(),
+		Body:        v.Child(4).Str(),
+		Timestamp:   v.Child(5).Uint64(),
+		RootDirTree: hex.EncodeToString(v.Child(6).Bytes()),
+		RootDirMeta: hex.EncodeToString(v.Child(7).Bytes()),
+	}
+	if err := v.Err(); err != nil {
+		return nil, fmt.Errorf("commit %s: %w", csum, err)
+	}
+	return c, nil
+}
+
+// ReadDirTree reads and decodes the dirtree object identified by csum, returning
+// its file and subdirectory entries.
+func (r *Repo) ReadDirTree(csum string) ([]DirEntry, error) {
+	v, err := r.readObject(csum, "dirtree", dirTreeFormat)
+	if err != nil {
+		return nil, err
+	}
+	return decodeDirTree(csum, v)
+}
+
+// decodeDirTree decodes a dirtree object already wrapped as a GVariant.
+func decodeDirTree(csum string, v *gvariant.Value) ([]DirEntry, error) {
+	var entries []DirEntry
+	files := v.Child(0)
+	for i := 0; i < files.Len(); i++ {
+		e := files.At(i)
+		entries = append(entries, DirEntry{
+			Name:     e.Child(0).Str(),
+			Checksum: hex.EncodeToString(e.Child(1).Bytes()),
+		})
+	}
+	dirs := v.Child(1)
+	for i := 0; i < dirs.Len(); i++ {
+		e := dirs.At(i)
+		entries = append(entries, DirEntry{
+			Name:     e.Child(0).Str(),
+			Checksum: hex.EncodeToString(e.Child(1).Bytes()),
+			MetaSum:  hex.EncodeToString(e.Child(2).Bytes()),
+			IsDir:    true,
+		})
+	}
+	if err := v.Err(); err != nil {
+		return nil, fmt.Errorf("dirtree %s: %w", csum, err)
+	}
+	return entries, nil
+}
+

--- a/pkg/ostree/progress_test.go
+++ b/pkg/ostree/progress_test.go
@@ -1,0 +1,145 @@
+//go:build linux
+
+package ostree
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestPullProgressReported verifies the Progress callback fires during a full
+// pull, ends with all content objects done, and reports monotonic byte totals.
+func TestPullProgressReported(t *testing.T) {
+	requireOstree(t)
+	srcRepo, ref, _ := makeContentRepo(t)
+	srv := httptest.NewServer(http.FileServer(http.Dir(srcRepo)))
+	defer srv.Close()
+
+	var (
+		mu       sync.Mutex
+		events   []PullProgress
+		maxBytes uint64
+		mono     = true
+	)
+	dest := filepath.Join(t.TempDir(), "dest")
+	res, err := OpenRepo(dest).Pull(context.Background(), PullOptions{
+		Remote: RemoteConfig{BaseURL: srv.URL},
+		Ref:    ref,
+		Progress: func(p PullProgress) {
+			mu.Lock()
+			defer mu.Unlock()
+			if p.BytesDownloaded < maxBytes {
+				mono = false
+			}
+			maxBytes = p.BytesDownloaded
+			events = append(events, p)
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(events) == 0 {
+		t.Fatal("progress callback was never invoked")
+	}
+	if !mono {
+		t.Error("BytesDownloaded was not monotonic non-decreasing")
+	}
+	// Find the final content-phase event; it should report all objects done.
+	var lastContent *PullProgress
+	for i := range events {
+		if events[i].Phase == PhaseContent {
+			lastContent = &events[i]
+		}
+	}
+	if lastContent == nil {
+		t.Fatal("no content-phase progress events")
+	}
+	if lastContent.ObjectsTotal == 0 || lastContent.ObjectsDone != lastContent.ObjectsTotal {
+		t.Errorf("final content progress = %d/%d, want done==total>0",
+			lastContent.ObjectsDone, lastContent.ObjectsTotal)
+	}
+	if maxBytes == 0 || res.BytesDownloaded == 0 {
+		t.Errorf("expected non-zero bytes: progress max=%d result=%d", maxBytes, res.BytesDownloaded)
+	}
+}
+
+// TestPullProgressNilSafe confirms a pull with no Progress callback works.
+func TestPullProgressNilSafe(t *testing.T) {
+	requireOstree(t)
+	srcRepo, ref, commit := makeContentRepo(t)
+	srv := httptest.NewServer(http.FileServer(http.Dir(srcRepo)))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "dest")
+	res, err := OpenRepo(dest).Pull(context.Background(), PullOptions{
+		Remote: RemoteConfig{BaseURL: srv.URL}, Ref: ref, // Progress nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Commit != commit {
+		t.Fatalf("commit %s want %s", res.Commit, commit)
+	}
+}
+
+// TestPullProgressInObject verifies byte progress advances *within* a single
+// large object: pulling a repo whose only sizable object is ~2MB with
+// Concurrency 1 must yield multiple content-phase snapshots with increasing
+// byte counts before the object completes.
+func TestPullProgressInObject(t *testing.T) {
+	requireOstree(t)
+	dir := t.TempDir()
+	srcRepo := filepath.Join(dir, "repo")
+	tree := filepath.Join(dir, "tree")
+	if err := os.MkdirAll(filepath.Join(tree, "d"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	run(t, "ostree", "--repo="+srcRepo, "init", "--mode=archive")
+	writeRandom(t, filepath.Join(tree, "d", "big"), 3_000_000) // incompressible
+	commit := strings.TrimSpace(run(t, "ostree", "--repo="+srcRepo, "commit", "--branch=main",
+		"--owner-uid=0", "--owner-gid=0", "--tree=dir="+tree))
+
+	srv := httptest.NewServer(http.FileServer(http.Dir(srcRepo)))
+	defer srv.Close()
+
+	var (
+		mu     sync.Mutex
+		bytes  []uint64
+	)
+	dest := filepath.Join(t.TempDir(), "dest")
+	_, err := OpenRepo(dest).Pull(context.Background(), PullOptions{
+		Remote:      RemoteConfig{BaseURL: srv.URL},
+		Commit:      commit,
+		Concurrency: 1,
+		Progress: func(p PullProgress) {
+			if p.Phase == PhaseContent {
+				mu.Lock()
+				bytes = append(bytes, p.BytesDownloaded)
+				mu.Unlock()
+			}
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	// Expect several increasing byte snapshots (throttled to ~100ms, but a 3MB
+	// object over the loopback still yields at least a couple, plus completion).
+	distinct := map[uint64]bool{}
+	for _, b := range bytes {
+		distinct[b] = true
+	}
+	if len(distinct) < 2 {
+		t.Errorf("expected multiple distinct byte snapshots within the object, got %v", bytes)
+	}
+}

--- a/pkg/ostree/pull.go
+++ b/pkg/ostree/pull.go
@@ -1,0 +1,384 @@
+//go:build linux
+
+package ostree
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// PullOptions configures a pull. Exactly one of Commit or Ref identifies what to
+// fetch; if both are empty Pull fails. When Ref is given, it is resolved against
+// the remote's refs/heads/<ref>.
+type PullOptions struct {
+	Remote RemoteConfig
+	Ref    string // e.g. "main" (resolved via remote refs/heads)
+	Commit string // explicit commit checksum (takes precedence over Ref)
+	// From is the current (base) commit. When set and UseDelta is true, Pull
+	// tries the from->to static delta the remote publishes before falling back
+	// to a full object pull.
+	From string
+	// UseDelta enables the static-delta fast path (default: enabled when From is
+	// set). Set NoDelta to force a full object pull.
+	NoDelta bool
+	// Concurrency bounds parallel content-object downloads (default 4).
+	Concurrency int
+}
+
+// PullResult reports what a pull did.
+type PullResult struct {
+	Commit          string
+	MetaFetched     int    // metadata objects downloaded
+	ContentFetched  int    // content objects downloaded
+	ObjectsSkipped  int    // objects already present (resume)
+	BytesDownloaded uint64 // total bytes pulled over the wire this run
+	UsedDelta       bool   // true if the static-delta fast path was used
+}
+
+// fetcher pairs a transport with the destination repo and accumulates stats.
+type fetcher struct {
+	t    transport
+	repo *Repo
+
+	mu    sync.Mutex
+	stats PullResult
+}
+
+// Pull fetches the commit (and every object it references) from the remote
+// archive repo into the local bare-user repo, resuming any prior interrupted
+// attempt at both the object and byte level. It is safe to re-run.
+func (r *Repo) Pull(ctx context.Context, opts PullOptions) (*PullResult, error) {
+	if err := r.ensureRepo(); err != nil {
+		return nil, err
+	}
+	// Resolve the repo mode once now, before any concurrent content writes read
+	// it, so the lazy cache is populated single-threaded.
+	r.repoMode()
+
+	t, err := newTransport(opts.Remote)
+	if err != nil {
+		return nil, err
+	}
+	f := &fetcher{t: t, repo: r}
+
+	commit := opts.Commit
+	if commit == "" {
+		if opts.Ref == "" {
+			return nil, fmt.Errorf("pull: neither Commit nor Ref given")
+		}
+		commit, err = f.resolveRemoteRef(ctx, opts.Ref)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if !hexCsumRe.MatchString(commit) {
+		return nil, fmt.Errorf("pull: %q is not a commit checksum", commit)
+	}
+
+	// Mark the commit partial up front; cleared only once every referenced
+	// object is present, so an interrupted pull resumes safely.
+	if err := r.markCommitPartial(commit, true); err != nil {
+		return nil, err
+	}
+
+	// 1. Commit object (+ optional detached commitmeta).
+	if err := f.fetchMetadata(ctx, commit, "commit"); err != nil {
+		return nil, fmt.Errorf("fetch commit: %w", err)
+	}
+	if err := f.fetchOptionalMetadata(ctx, commit, "commitmeta"); err != nil {
+		return nil, err
+	}
+	c, err := r.ReadCommit(commit)
+	if err != nil {
+		return nil, err
+	}
+
+	// 2. Prefer the static-delta fast path when a base commit is given and the
+	// remote publishes a from->to delta; otherwise fall back to a full pull.
+	deltaDone := false
+	if opts.From != "" && !opts.NoDelta {
+		ok, err := f.tryDeltaPull(ctx, opts.From, commit)
+		if err != nil {
+			return nil, err
+		}
+		deltaDone = ok
+		f.stats.UsedDelta = ok
+	}
+
+	if !deltaDone {
+		// Full object pull: walk the tree, fetching metadata depth-first and
+		// collecting the set of content objects to download.
+		content := newCsumSet()
+		if err := f.walkDirTree(ctx, c.RootDirTree, c.RootDirMeta, content); err != nil {
+			return nil, err
+		}
+		// Fetch content objects concurrently (each resumable).
+		if err := f.fetchContentObjects(ctx, content.list(), opts.Concurrency); err != nil {
+			return nil, err
+		}
+	}
+
+	// 3. All objects present: clear the partial marker, then write the ref.
+	if err := r.markCommitPartial(commit, false); err != nil {
+		return nil, err
+	}
+	if opts.Ref != "" {
+		if err := r.writeRef(opts.Ref, commit); err != nil {
+			return nil, err
+		}
+	}
+
+	f.stats.Commit = commit
+	res := f.stats
+	return &res, nil
+}
+
+// resolveRemoteRef fetches refs/heads/<ref> from the remote and returns the
+// commit checksum.
+func (f *fetcher) resolveRemoteRef(ctx context.Context, ref string) (string, error) {
+	data, err := f.get(ctx, filepath.ToSlash(filepath.Join("refs", "heads", ref)))
+	if err != nil {
+		return "", fmt.Errorf("resolve remote ref %q: %w", ref, err)
+	}
+	csum := trimRef(data)
+	if !hexCsumRe.MatchString(csum) {
+		return "", fmt.Errorf("remote ref %q: %q is not a commit checksum", ref, csum)
+	}
+	return csum, nil
+}
+
+func trimRef(b []byte) string {
+	s := string(b)
+	for len(s) > 0 && (s[len(s)-1] == '\n' || s[len(s)-1] == '\r' || s[len(s)-1] == ' ') {
+		s = s[:len(s)-1]
+	}
+	return s
+}
+
+// walkDirTree fetches a dirtree and its dirmeta (skipping any already present),
+// records its file content objects, and recurses into subdirectories.
+func (f *fetcher) walkDirTree(ctx context.Context, treeCsum, metaCsum string, content *csumSet) error {
+	if err := f.fetchMetadata(ctx, metaCsum, "dirmeta"); err != nil {
+		return fmt.Errorf("fetch dirmeta %s: %w", metaCsum, err)
+	}
+	if err := f.fetchMetadata(ctx, treeCsum, "dirtree"); err != nil {
+		return fmt.Errorf("fetch dirtree %s: %w", treeCsum, err)
+	}
+	entries, err := f.repo.ReadDirTree(treeCsum)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if e.IsDir {
+			if err := f.walkDirTree(ctx, e.Checksum, e.MetaSum, content); err != nil {
+				return err
+			}
+		} else {
+			content.add(e.Checksum)
+		}
+	}
+	return nil
+}
+
+// fetchMetadata downloads a metadata object (small; no byte-resume needed) and
+// writes it verbatim, unless it is already present.
+func (f *fetcher) fetchMetadata(ctx context.Context, csum, ext string) error {
+	if f.repo.hasObject(csum, ext) {
+		f.addSkipped()
+		return nil
+	}
+	data, err := f.get(ctx, objectRelPath(csum, ext))
+	if err != nil {
+		return err
+	}
+	if err := f.repo.writeMetadataObject(csum, ext, data); err != nil {
+		return err
+	}
+	f.addMeta(uint64(len(data)))
+	return nil
+}
+
+// fetchOptionalMetadata is like fetchMetadata but tolerates a missing object
+// (e.g. detached commitmeta, which many commits lack).
+func (f *fetcher) fetchOptionalMetadata(ctx context.Context, csum, ext string) error {
+	err := f.fetchMetadata(ctx, csum, ext)
+	if err != nil && isNotFound(err) {
+		return nil
+	}
+	return err
+}
+
+// fetchContentObjects downloads each content object (resumably) and converts it
+// to a bare-user .file object, with bounded concurrency.
+func (f *fetcher) fetchContentObjects(ctx context.Context, csums []string, concurrency int) error {
+	if concurrency <= 0 {
+		concurrency = 4
+	}
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
+	var (
+		errMu    sync.Mutex
+		firstErr error
+	)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	for _, csum := range csums {
+		csum := csum
+		if f.repo.hasObject(csum, "file") {
+			f.addSkipped()
+			continue
+		}
+		// Acquire a slot, or stop launching work once the context is cancelled
+		// (e.g. an earlier fetch failed). Taking the ctx.Done() branch must NOT
+		// launch a goroutine: it never acquired a slot, so its release would
+		// unbalance the semaphore and deadlock wg.Wait().
+		select {
+		case <-ctx.Done():
+			// fall through to break out of the loop below
+		case sem <- struct{}{}:
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer func() { <-sem }()
+				if err := f.fetchOneContent(ctx, csum); err != nil {
+					errMu.Lock()
+					if firstErr == nil {
+						firstErr = err
+						cancel()
+					}
+					errMu.Unlock()
+				}
+			}()
+			continue
+		}
+		break
+	}
+	wg.Wait()
+	if firstErr != nil {
+		return firstErr
+	}
+	// The loop may have stopped early because the parent context was cancelled
+	// without any fetch recording an error; surface that rather than a false ok.
+	return ctx.Err()
+}
+
+// fetchOneContent resumably downloads a single .filez content object into a
+// .part sidecar, then parses, verifies and writes the bare-user object.
+func (f *fetcher) fetchOneContent(ctx context.Context, csum string) error {
+	part := filepath.Join(f.repo.path, "tmp", csum+".filez.part")
+	if err := os.MkdirAll(filepath.Dir(part), 0o755); err != nil {
+		return err
+	}
+	n, err := f.downloadResumable(ctx, objectRelPath(csum, "filez"), part)
+	if err != nil {
+		return fmt.Errorf("download %s: %w", csum, err)
+	}
+
+	data, err := os.ReadFile(part)
+	if err != nil {
+		return err
+	}
+	hdr, content, err := parseFilez(data)
+	if err != nil {
+		// A corrupt/incomplete part: drop it so a re-run starts clean.
+		os.Remove(part)
+		return fmt.Errorf("parse %s: %w", csum, err)
+	}
+	if err := f.repo.writeContentObject(csum, hdr, content); err != nil {
+		os.Remove(part)
+		return err
+	}
+	os.Remove(part)
+	f.addContent(uint64(n))
+	return nil
+}
+
+// downloadResumable downloads relPath into the part file, resuming from its
+// current size when the server honors a Range request. It returns the number of
+// bytes transferred during THIS call (i.e. excluding bytes already on disk from
+// a previous attempt). When the server ignores Range (responds 200), the part
+// is truncated and refetched from the start.
+func (f *fetcher) downloadResumable(ctx context.Context, relPath, part string) (int64, error) {
+	var offset int64
+	if fi, err := os.Stat(part); err == nil {
+		offset = fi.Size()
+	}
+
+	rc, resumed, err := f.t.open(ctx, relPath, offset)
+	if err != nil {
+		return 0, err
+	}
+	defer rc.Close()
+
+	flags := os.O_CREATE | os.O_WRONLY
+	if resumed {
+		flags |= os.O_APPEND // continue after the existing bytes
+	} else {
+		flags |= os.O_TRUNC // whole object (fresh, or server ignored Range)
+	}
+	out, err := os.OpenFile(part, flags, 0o644)
+	if err != nil {
+		return 0, err
+	}
+	defer out.Close()
+
+	n, err := io.Copy(out, rc)
+	if err != nil {
+		return n, err // partial bytes are kept on disk for the next resume
+	}
+	return n, nil
+}
+
+// get downloads a whole small object into memory (used for metadata and refs).
+func (f *fetcher) get(ctx context.Context, relPath string) ([]byte, error) {
+	rc, _, err := f.t.open(ctx, relPath, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+	return io.ReadAll(rc)
+}
+
+// --- stats helpers (concurrency-safe) ---
+
+func (f *fetcher) addMeta(n uint64) {
+	f.mu.Lock()
+	f.stats.MetaFetched++
+	f.stats.BytesDownloaded += n
+	f.mu.Unlock()
+}
+
+func (f *fetcher) addContent(n uint64) {
+	f.mu.Lock()
+	f.stats.ContentFetched++
+	f.stats.BytesDownloaded += n
+	f.mu.Unlock()
+}
+
+func (f *fetcher) addSkipped() {
+	f.mu.Lock()
+	f.stats.ObjectsSkipped++
+	f.mu.Unlock()
+}
+
+// csumSet is a small ordered, deduplicated set of checksums.
+type csumSet struct {
+	seen  map[string]bool
+	order []string
+}
+
+func newCsumSet() *csumSet { return &csumSet{seen: map[string]bool{}} }
+
+func (s *csumSet) add(c string) {
+	if !s.seen[c] {
+		s.seen[c] = true
+		s.order = append(s.order, c)
+	}
+}
+
+func (s *csumSet) list() []string { return s.order }

--- a/pkg/ostree/pull.go
+++ b/pkg/ostree/pull.go
@@ -9,7 +9,32 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 )
+
+// PullPhase identifies which stage of a pull is running.
+type PullPhase string
+
+const (
+	PhaseMetadata PullPhase = "metadata" // commit/dirtree/dirmeta objects
+	PhaseContent  PullPhase = "content"  // .filez content objects (full pull)
+	PhaseDelta    PullPhase = "delta"    // static-delta parts
+)
+
+// PullProgress is a snapshot of pull progress. ObjectsDone counts whole objects
+// completed in the current phase; ObjectsTotal is the total to fetch in that
+// phase (0 when unknown). BytesDownloaded is cumulative over the wire this run.
+type PullProgress struct {
+	Phase           PullPhase
+	ObjectsDone     int
+	ObjectsTotal    int
+	BytesDownloaded uint64
+	Commit          string
+}
+
+// ProgressFunc receives progress snapshots. It may be called concurrently and
+// frequently, so implementations must be cheap and non-blocking. Optional.
+type ProgressFunc func(PullProgress)
 
 // PullOptions configures a pull. Exactly one of Commit or Ref identifies what to
 // fetch; if both are empty Pull fails. When Ref is given, it is resolved against
@@ -27,6 +52,9 @@ type PullOptions struct {
 	NoDelta bool
 	// Concurrency bounds parallel content-object downloads (default 4).
 	Concurrency int
+	// Progress, if set, receives progress snapshots during the pull. Optional;
+	// nil means no reporting.
+	Progress ProgressFunc
 }
 
 // PullResult reports what a pull did.
@@ -46,6 +74,74 @@ type fetcher struct {
 
 	mu    sync.Mutex
 	stats PullResult
+
+	// progress reporting (all read/written under mu)
+	progress     ProgressFunc // optional
+	curPhase     PullPhase    // phase attributed to progress events
+	contentTotal int          // total objects in the current phase (0 if unknown)
+	contentDone  int          // content/delta objects completed (fetched or already present)
+	lastEmit     time.Time    // last throttled byte-progress emission
+}
+
+// emit reports the current progress snapshot to the callback. Caller must NOT
+// hold f.mu; it snapshots under the lock and calls the callback outside it.
+func (f *fetcher) emit() {
+	f.mu.Lock()
+	if f.progress == nil {
+		f.mu.Unlock()
+		return
+	}
+	p := PullProgress{
+		Phase:           f.curPhase,
+		ObjectsDone:     f.contentDoneLocked(),
+		ObjectsTotal:    f.contentTotal,
+		BytesDownloaded: f.stats.BytesDownloaded,
+		Commit:          f.stats.Commit,
+	}
+	cb := f.progress
+	f.mu.Unlock()
+	cb(p)
+}
+
+// contentDoneLocked returns how many objects count as completed in the current
+// phase. Caller must hold f.mu. For metadata it is metadata objects fetched;
+// for content/delta it is content objects completed (fetched or already present).
+func (f *fetcher) contentDoneLocked() int {
+	if f.curPhase == PhaseMetadata {
+		return f.stats.MetaFetched
+	}
+	return f.contentDone
+}
+
+// addBytes adds n bytes (from a content/delta object body) to the running total
+// and emits a throttled snapshot so progress advances within a large object
+// without a callback per read. Content/delta bytes are counted here only (not
+// in addContent), so wrapping the download reader is the single byte source.
+func (f *fetcher) addBytes(n uint64) {
+	f.mu.Lock()
+	f.stats.BytesDownloaded += n
+	emit := f.progress != nil && time.Since(f.lastEmit) >= 100*time.Millisecond
+	if emit {
+		f.lastEmit = time.Now()
+	}
+	f.mu.Unlock()
+	if emit {
+		f.emit()
+	}
+}
+
+// progressReader wraps a reader to report bytes read to the fetcher.
+type progressReader struct {
+	r io.Reader
+	f *fetcher
+}
+
+func (p *progressReader) Read(b []byte) (int, error) {
+	n, err := p.r.Read(b)
+	if n > 0 {
+		p.f.addBytes(uint64(n))
+	}
+	return n, err
 }
 
 // Pull fetches the commit (and every object it references) from the remote
@@ -63,7 +159,7 @@ func (r *Repo) Pull(ctx context.Context, opts PullOptions) (*PullResult, error) 
 	if err != nil {
 		return nil, err
 	}
-	f := &fetcher{t: t, repo: r}
+	f := &fetcher{t: t, repo: r, progress: opts.Progress, curPhase: PhaseMetadata}
 
 	commit := opts.Commit
 	if commit == "" {
@@ -78,6 +174,7 @@ func (r *Repo) Pull(ctx context.Context, opts PullOptions) (*PullResult, error) 
 	if !hexCsumRe.MatchString(commit) {
 		return nil, fmt.Errorf("pull: %q is not a commit checksum", commit)
 	}
+	f.stats.Commit = commit // so progress snapshots carry the commit
 
 	// Mark the commit partial up front; cleared only once every referenced
 	// object is present, so an interrupted pull resumes safely.
@@ -116,7 +213,12 @@ func (r *Repo) Pull(ctx context.Context, opts PullOptions) (*PullResult, error) 
 		if err := f.walkDirTree(ctx, c.RootDirTree, c.RootDirMeta, content); err != nil {
 			return nil, err
 		}
-		// Fetch content objects concurrently (each resumable).
+		// Fetch content objects concurrently (each resumable). The total is known
+		// up front, so progress can report N/M objects.
+		f.mu.Lock()
+		f.curPhase = PhaseContent
+		f.contentTotal = len(content.list())
+		f.mu.Unlock()
 		if err := f.fetchContentObjects(ctx, content.list(), opts.Concurrency); err != nil {
 			return nil, err
 		}
@@ -230,7 +332,7 @@ func (f *fetcher) fetchContentObjects(ctx context.Context, csums []string, concu
 	for _, csum := range csums {
 		csum := csum
 		if f.repo.hasObject(csum, "file") {
-			f.addSkipped()
+			f.addContentSkipped()
 			continue
 		}
 		// Acquire a slot, or stop launching work once the context is cancelled
@@ -274,8 +376,7 @@ func (f *fetcher) fetchOneContent(ctx context.Context, csum string) error {
 	if err := os.MkdirAll(filepath.Dir(part), 0o755); err != nil {
 		return err
 	}
-	n, err := f.downloadResumable(ctx, objectRelPath(csum, "filez"), part)
-	if err != nil {
+	if _, err := f.downloadResumable(ctx, objectRelPath(csum, "filez"), part); err != nil {
 		return fmt.Errorf("download %s: %w", csum, err)
 	}
 
@@ -294,7 +395,7 @@ func (f *fetcher) fetchOneContent(ctx context.Context, csum string) error {
 		return err
 	}
 	os.Remove(part)
-	f.addContent(uint64(n))
+	f.addContent()
 	return nil
 }
 
@@ -327,7 +428,7 @@ func (f *fetcher) downloadResumable(ctx context.Context, relPath, part string) (
 	}
 	defer out.Close()
 
-	n, err := io.Copy(out, rc)
+	n, err := io.Copy(out, &progressReader{r: rc, f: f})
 	if err != nil {
 		return n, err // partial bytes are kept on disk for the next resume
 	}
@@ -351,19 +452,37 @@ func (f *fetcher) addMeta(n uint64) {
 	f.stats.MetaFetched++
 	f.stats.BytesDownloaded += n
 	f.mu.Unlock()
+	f.emit()
 }
 
-func (f *fetcher) addContent(n uint64) {
+// addContent records a completed content object. Its bytes were already counted
+// live through the wrapped download reader (addBytes), so only the count is
+// incremented here.
+func (f *fetcher) addContent() {
 	f.mu.Lock()
 	f.stats.ContentFetched++
-	f.stats.BytesDownloaded += n
+	f.contentDone++
 	f.mu.Unlock()
+	f.emit()
 }
 
+// addSkipped records a metadata object that is already present (resume). It does
+// not advance content-phase completion.
 func (f *fetcher) addSkipped() {
 	f.mu.Lock()
 	f.stats.ObjectsSkipped++
 	f.mu.Unlock()
+	f.emit()
+}
+
+// addContentSkipped records a content object already present on disk: it counts
+// as both a skipped object and a completed content-phase object.
+func (f *fetcher) addContentSkipped() {
+	f.mu.Lock()
+	f.stats.ObjectsSkipped++
+	f.contentDone++
+	f.mu.Unlock()
+	f.emit()
 }
 
 // csumSet is a small ordered, deduplicated set of checksums.

--- a/pkg/ostree/pull_delta.go
+++ b/pkg/ostree/pull_delta.go
@@ -1,0 +1,85 @@
+//go:build linux
+
+package ostree
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+)
+
+// tryDeltaPull attempts the static-delta fast path: download the from->to delta
+// superblock and parts the remote publishes (resumably), then apply it locally.
+// It returns (true, nil) on success, (false, nil) when the remote has no such
+// delta (so the caller falls back to a full pull), or (false, err) on a real
+// failure.
+func (f *fetcher) tryDeltaPull(ctx context.Context, from, to string) (bool, error) {
+	rel, err := staticDeltaDir(from, to)
+	if err != nil {
+		return false, err
+	}
+	// Fetch the superblock; a 404 means no delta is published for this pair.
+	sbRel := path.Join(rel, "superblock")
+	sbData, err := f.get(ctx, sbRel)
+	if err != nil {
+		if isNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("fetch delta superblock: %w", err)
+	}
+
+	// Determine how many parts the delta has (one per meta entry) and their
+	// sizes, by parsing the superblock we just fetched.
+	nParts, err := deltaPartCount(sbData)
+	if err != nil {
+		return false, fmt.Errorf("parse delta superblock: %w", err)
+	}
+
+	// Persist the superblock and parts into the local delta directory, so
+	// applyStaticDelta can read them (and so a re-run resumes).
+	base := filepath.Join(f.repo.path, filepath.FromSlash(rel))
+	if err := os.MkdirAll(base, 0o755); err != nil {
+		return false, err
+	}
+	if err := os.WriteFile(filepath.Join(base, "superblock"), sbData, 0o644); err != nil {
+		return false, err
+	}
+	f.addMeta(uint64(len(sbData)))
+
+	for i := 0; i < nParts; i++ {
+		partRel := path.Join(rel, fmt.Sprintf("%d", i))
+		dst := filepath.Join(base, fmt.Sprintf("%d", i))
+		// Resumable download into a .part sidecar, then move into place.
+		partFile := dst + ".part"
+		n, err := f.downloadResumable(ctx, partRel, partFile)
+		if err != nil {
+			return false, fmt.Errorf("fetch delta part %d: %w", i, err)
+		}
+		if err := os.Rename(partFile, dst); err != nil {
+			return false, err
+		}
+		f.addContent(uint64(n))
+	}
+
+	// Apply the delta locally (verifies part and produced-object checksums).
+	if err := f.repo.applyStaticDelta(from, to); err != nil {
+		return false, fmt.Errorf("apply delta: %w", err)
+	}
+	return true, nil
+}
+
+// deltaPartCount returns the number of delta parts (meta entries) in a
+// superblock blob.
+func deltaPartCount(sbData []byte) (int, error) {
+	sb, err := newSuperblock(sbData)
+	if err != nil {
+		return 0, err
+	}
+	n := sb.Child(sbMetaEntries).Len()
+	if err := sb.Err(); err != nil {
+		return 0, err
+	}
+	return n, nil
+}

--- a/pkg/ostree/pull_delta.go
+++ b/pkg/ostree/pull_delta.go
@@ -48,19 +48,25 @@ func (f *fetcher) tryDeltaPull(ctx context.Context, from, to string) (bool, erro
 	}
 	f.addMeta(uint64(len(sbData)))
 
+	// Downloading the delta parts: report progress as "part N of nParts".
+	f.mu.Lock()
+	f.curPhase = PhaseDelta
+	f.contentTotal = nParts
+	f.mu.Unlock()
+
 	for i := 0; i < nParts; i++ {
 		partRel := path.Join(rel, fmt.Sprintf("%d", i))
 		dst := filepath.Join(base, fmt.Sprintf("%d", i))
 		// Resumable download into a .part sidecar, then move into place.
 		partFile := dst + ".part"
-		n, err := f.downloadResumable(ctx, partRel, partFile)
+		_, err := f.downloadResumable(ctx, partRel, partFile)
 		if err != nil {
 			return false, fmt.Errorf("fetch delta part %d: %w", i, err)
 		}
 		if err := os.Rename(partFile, dst); err != nil {
 			return false, err
 		}
-		f.addContent(uint64(n))
+		f.addContent()
 	}
 
 	// Apply the delta locally (verifies part and produced-object checksums).

--- a/pkg/ostree/pull_delta_test.go
+++ b/pkg/ostree/pull_delta_test.go
@@ -1,0 +1,90 @@
+//go:build linux
+
+package ostree
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestPullWithDelta pulls the `from` commit fully, then pulls `to` with From set
+// so the static-delta fast path runs over HTTP. It asserts the delta path was
+// used, far fewer/els different objects were transferred than a full pull, and
+// the result fscks clean and matches the source.
+func TestPullWithDelta(t *testing.T) {
+	requireOstree(t)
+	srcRepo, from, to := makeDeltaContentRepo(t)
+	srv := httptest.NewServer(http.FileServer(http.Dir(srcRepo)))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "dest")
+	r := OpenRepo(dest).WithMode(modeBareUserOnly)
+	ctx := context.Background()
+
+	// Base commit (full pull).
+	if _, err := r.Pull(ctx, PullOptions{Remote: RemoteConfig{BaseURL: srv.URL}, Commit: from}); err != nil {
+		t.Fatalf("pull from: %v", err)
+	}
+
+	// Update via delta.
+	res, err := r.Pull(ctx, PullOptions{
+		Remote: RemoteConfig{BaseURL: srv.URL},
+		Ref:    "main",
+		Commit: to,
+		From:   from,
+	})
+	if err != nil {
+		t.Fatalf("delta pull: %v", err)
+	}
+	if !res.UsedDelta {
+		t.Fatalf("expected delta path to be used, got full pull: %+v", res)
+	}
+
+	out := run(t, "ostree", "--repo="+dest, "fsck")
+	if !strings.Contains(out, "no errors found") {
+		t.Errorf("fsck failed:\n%s", out)
+	}
+	got, err := r.ResolveRef("main")
+	if err != nil || got != to {
+		t.Fatalf("ResolveRef(main)=%q,%v want %s", got, err, to)
+	}
+	srcLs := run(t, "ostree", "--repo="+srcRepo, "ls", "-R", to)
+	dstLs := run(t, "ostree", "--repo="+dest, "ls", "-R", to)
+	if srcLs != dstLs {
+		t.Errorf("listings differ:\n--- src ---\n%s\n--- dst ---\n%s", srcLs, dstLs)
+	}
+}
+
+// TestPullDeltaFallback confirms that when no delta is published for the pair,
+// Pull falls back to a full object pull and still succeeds.
+func TestPullDeltaFallback(t *testing.T) {
+	requireOstree(t)
+	// A repo with two commits but NO generated static delta.
+	srcRepo, _, to := makeContentRepoOpts(t, true)
+	// Fabricate a plausible but absent `from` so the delta superblock 404s.
+	const absentFrom = "0000000000000000000000000000000000000000000000000000000000000000"
+	srv := httptest.NewServer(http.FileServer(http.Dir(srcRepo)))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "dest")
+	r := OpenRepo(dest).WithMode(modeBareUserOnly)
+	res, err := r.Pull(context.Background(), PullOptions{
+		Remote: RemoteConfig{BaseURL: srv.URL},
+		Commit: to,
+		From:   absentFrom, // no delta exists -> fall back to full pull
+	})
+	if err != nil {
+		t.Fatalf("pull: %v", err)
+	}
+	if res.UsedDelta {
+		t.Fatalf("expected full-pull fallback, but delta was used")
+	}
+	out := run(t, "ostree", "--repo="+dest, "fsck")
+	if !strings.Contains(out, "no errors found") {
+		t.Errorf("fsck failed:\n%s", out)
+	}
+}

--- a/pkg/ostree/pull_size.go
+++ b/pkg/ostree/pull_size.go
@@ -1,0 +1,240 @@
+//go:build linux
+
+package ostree
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"path"
+
+	"github.com/foundriesio/ostreeuploader/pkg/gvariant"
+	"github.com/foundriesio/ostreeuploader/pkg/varint"
+)
+
+// PullSize reports the estimated download size of a full (non-delta) pull of a
+// commit: the sum of the compressed on-wire sizes of every object the commit
+// references. Metadata is the commit/dirtree/dirmeta objects; Content is the
+// .filez file objects.
+type PullSize struct {
+	// Compressed is the total number of bytes that would be downloaded (the sum
+	// of every referenced object's on-wire size). This is the figure to compare
+	// against network/transfer budgets.
+	Compressed uint64 `json:"compressed"`
+	// Uncompressed is the total decompressed size of the objects. It is only
+	// populated when the estimate came from the commit's ostree.sizes metadata
+	// (FromSizesMeta true); it is 0 otherwise.
+	Uncompressed uint64 `json:"uncompressed"`
+	// MetaObjects / ContentObjects count the objects of each kind.
+	MetaObjects    int `json:"meta_objects"`
+	ContentObjects int `json:"content_objects"`
+	// FromSizesMeta reports whether the sizes came from the commit's ostree.sizes
+	// metadata (a single fetch) rather than probing every object over the network.
+	FromSizesMeta bool `json:"from_sizes_meta"`
+}
+
+// ResolveRemoteRef fetches refs/heads/<ref> from a remote repo and returns the
+// commit checksum it points to.
+func ResolveRemoteRef(ctx context.Context, rc RemoteConfig, ref string) (string, error) {
+	t, err := newTransport(rc)
+	if err != nil {
+		return "", err
+	}
+	rd, _, err := t.open(ctx, path.Join("refs", "heads", ref), 0)
+	if err != nil {
+		return "", fmt.Errorf("resolve remote ref %q: %w", ref, err)
+	}
+	defer rd.Close()
+	data, err := io.ReadAll(rd)
+	if err != nil {
+		return "", fmt.Errorf("resolve remote ref %q: %w", ref, err)
+	}
+	csum := trimRef(data)
+	if !hexCsumRe.MatchString(csum) {
+		return "", fmt.Errorf("remote ref %q: %q is not a commit checksum", ref, csum)
+	}
+	return csum, nil
+}
+
+// RemotePullSize estimates the download size of a full pull of commit from a
+// remote archive repo, WITHOUT downloading object bodies.
+//
+// It requires the commit to have been built with `--generate-sizes`, so its
+// metadata carries an "ostree.sizes" table of every referenced object's
+// compressed and uncompressed size. The size is then computed from the commit
+// object alone (one fetch), and PullSize.Uncompressed is populated. When the
+// commit has no ostree.sizes metadata, ErrSizeUnavailable is returned.
+//
+// localRepo, if non-nil, is used to skip objects that are already present on
+// disk — so the returned size reflects only what would actually be downloaded,
+// not a full fresh-pull total.
+func RemotePullSize(ctx context.Context, rc RemoteConfig, commit string, localRepo *Repo) (PullSize, error) {
+	if !hexCsumRe.MatchString(commit) {
+		return PullSize{}, fmt.Errorf("pull-size: %q is not a commit checksum", commit)
+	}
+	t, err := newTransport(rc)
+	if err != nil {
+		return PullSize{}, err
+	}
+	e := &pullSizer{t: t, local: localRepo}
+
+	// Fetch the commit object and measure its on-wire size from the body length
+	// (avoids a separate HEAD, which some servers — e.g. Foundries treehub —
+	// do not support).
+	cv, commitSz, err := e.fetchMetaObject(ctx, commit, "commit", commitFormat)
+	if err != nil {
+		return PullSize{}, fmt.Errorf("commit %s: %w", commit, err)
+	}
+
+	// Use the ostree.sizes metadata table if the commit carries it.
+	// Pass 0 for commitSz when the commit is already local so we don't count it.
+	localCommitSz := commitSz
+	if e.hasLocally(commit, "commit") {
+		localCommitSz = 0
+	}
+	if ps, ok, err := pullSizeFromMeta(cv, localCommitSz, e.local); err != nil {
+		return PullSize{}, fmt.Errorf("commit %s ostree.sizes: %w", commit, err)
+	} else if ok {
+		return ps, nil
+	}
+
+	// The commit lacks ostree.sizes; no cheap source is available.
+	return PullSize{}, ErrSizeUnavailable
+}
+
+// pullSizeFromMeta computes the pull size from a commit's "ostree.sizes"
+// metadata, if present. commitSz is the on-wire size of the commit object
+// itself (not listed in ostree.sizes), already conditionally counted by the
+// caller. local, if non-nil, is used to skip objects already present on disk.
+// It returns ok=false when the commit has no ostree.sizes key (the caller then
+// falls back to walking).
+//
+// Each ostree.sizes entry (GVariant "ay") is: 32-byte sha256 checksum, a
+// varuint64 compressed ("archived") size, a varuint64 uncompressed ("unpacked")
+// size, and an optional trailing object-type byte. Mirrors libostree's
+// read_sizes_entry (ostree-core.c).
+func pullSizeFromMeta(commitVariant *gvariant.Value, commitSz uint64, local *Repo) (PullSize, bool, error) {
+	sizes, ok := lookupMetadata(commitVariant.Child(0), "ostree.sizes")
+	if !ok {
+		return PullSize{}, false, nil
+	}
+	// The variant holds an array of byte-arrays ("aay").
+	arr := sizes.Variant()
+	n := arr.Len()
+	// Seed with the commit object size/count, already zeroed by caller when local.
+	commitObjCount := 1
+	if commitSz == 0 {
+		commitObjCount = 0
+	}
+	ps := PullSize{
+		Compressed:    commitSz,
+		MetaObjects:   commitObjCount,
+		FromSizesMeta: true,
+	}
+	for i := 0; i < n; i++ {
+		entry := arr.At(i).Bytes()
+		if len(entry) < objCsumSizeLen+2 {
+			return PullSize{}, false, fmt.Errorf("entry %d too short (%d bytes)", i, len(entry))
+		}
+		csumHex := hex.EncodeToString(entry[:objCsumSizeLen])
+		buf := entry[objCsumSizeLen:] // skip the 32-byte checksum
+		archived, n1, err := varint.Uvarint(buf)
+		if err != nil {
+			return PullSize{}, false, fmt.Errorf("entry %d archived size: %w", i, err)
+		}
+		buf = buf[n1:]
+		unpacked, n2, err := varint.Uvarint(buf)
+		if err != nil {
+			return PullSize{}, false, fmt.Errorf("entry %d unpacked size: %w", i, err)
+		}
+		buf = buf[n2:]
+		// Optional object-type byte; default to a file object when absent.
+		objType := byte(objFile)
+		if len(buf) > 0 {
+			objType = buf[0]
+		}
+		// Skip objects already present in the local repo.
+		if local != nil && local.hasObject(csumHex, objExtForType(objType)) {
+			continue
+		}
+		ps.Compressed += archived
+		ps.Uncompressed += unpacked
+		if objType == byte(objFile) {
+			ps.ContentObjects++
+		} else {
+			ps.MetaObjects++
+		}
+	}
+	if err := arr.Err(); err != nil {
+		return PullSize{}, false, err
+	}
+	return ps, true, nil
+}
+
+// lookupMetadata finds a key in a commit's a{sv} metadata dictionary, returning
+// the associated value (still wrapped as a variant) and whether it was found.
+func lookupMetadata(meta *gvariant.Value, key string) (*gvariant.Value, bool) {
+	for i := 0; i < meta.Len(); i++ {
+		ent := meta.At(i)
+		if ent.Child(0).Str() == key {
+			return ent.Child(1), true
+		}
+	}
+	return nil, false
+}
+
+// objCsumSizeLen is the length of the binary sha256 checksum prefixing each
+// ostree.sizes entry.
+const objCsumSizeLen = 32
+
+// pullSizer holds the transport and optional local repo for RemotePullSize.
+type pullSizer struct {
+	t     transport
+	local *Repo // optional; when set, objects present here are skipped
+}
+
+// hasLocally reports whether the object is already present in the local repo.
+func (e *pullSizer) hasLocally(csum, ext string) bool {
+	return e.local != nil && e.local.hasObject(csum, ext)
+}
+
+// objExtForType maps an ostree object-type byte to its loose-object file
+// extension in a bare-user or bare-user-only repo.
+func objExtForType(t byte) string {
+	switch int(t) {
+	case objFile:
+		return "file"
+	case objDirTree:
+		return "dirtree"
+	case objDirMeta:
+		return "dirmeta"
+	case objCommit:
+		return "commit"
+	case objCommitMeta:
+		return "commitmeta"
+	default:
+		return "file"
+	}
+}
+
+// fetchMetaObject downloads a metadata object, decodes it as the given GVariant
+// type, and returns both the value and the on-wire byte count (len of raw body).
+// This avoids a separate HEAD request, so it works against servers that only
+// support GET (e.g. Foundries treehub).
+func (e *pullSizer) fetchMetaObject(ctx context.Context, csum, ext, format string) (*gvariant.Value, uint64, error) {
+	rc, _, err := e.t.open(ctx, objectRelPath(csum, ext), 0)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rc.Close()
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		return nil, 0, err
+	}
+	v, err := gvariant.New(data, format)
+	if err != nil {
+		return nil, 0, fmt.Errorf("decode %s object %s: %w", ext, csum, err)
+	}
+	return v, uint64(len(data)), nil
+}

--- a/pkg/ostree/pull_size_test.go
+++ b/pkg/ostree/pull_size_test.go
@@ -1,0 +1,188 @@
+//go:build linux
+
+package ostree
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// sumRepoObjectBytes sums the on-disk sizes of every loose object in an archive
+// repo, split into content (.filez) and metadata (.commit/.dirtree/.dirmeta).
+// For a freshly-created repo holding a single commit, this is the exact set of
+// objects a full pull of that commit would download.
+func sumRepoObjectBytes(t *testing.T, repo string) (content, meta uint64, nContent, nMeta int) {
+	t.Helper()
+	objRoot := filepath.Join(repo, "objects")
+	err := filepath.Walk(objRoot, func(p string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if fi.IsDir() {
+			return nil
+		}
+		switch {
+		case strings.HasSuffix(p, ".filez"):
+			content += uint64(fi.Size())
+			nContent++
+		case strings.HasSuffix(p, ".commit"), strings.HasSuffix(p, ".dirtree"), strings.HasSuffix(p, ".dirmeta"):
+			meta += uint64(fi.Size())
+			nMeta++
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk objects: %v", err)
+	}
+	return
+}
+
+// TestRemotePullSizeUnavailable confirms that a commit WITHOUT ostree.sizes
+// metadata yields ErrSizeUnavailable: there is no cheap source to size it and
+// the per-object probe has been removed.
+func TestRemotePullSizeUnavailable(t *testing.T) {
+	requireOstree(t)
+	repo, _, commit := makeContentRepoOpts(t, true) // no --generate-sizes
+	srv := httptest.NewServer(http.FileServer(http.Dir(repo)))
+	defer srv.Close()
+
+	_, err := RemotePullSize(context.Background(), RemoteConfig{BaseURL: srv.URL}, commit, nil)
+	if !errors.Is(err, ErrSizeUnavailable) {
+		t.Fatalf("RemotePullSize on a no-ostree.sizes commit: err = %v, want ErrSizeUnavailable", err)
+	}
+}
+
+// makeSizesRepo builds an archive repo whose single commit was generated with
+// `--generate-sizes`, so the commit carries the ostree.sizes metadata table.
+func makeSizesRepo(t *testing.T) (repo, ref, commit string) {
+	t.Helper()
+	dir := t.TempDir()
+	repo = filepath.Join(dir, "repo")
+	tree := filepath.Join(dir, "tree")
+	if err := os.MkdirAll(filepath.Join(tree, "usr", "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(tree, "etc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	run(t, "ostree", "--repo="+repo, "init", "--mode=archive")
+	writeRandom(t, filepath.Join(tree, "usr", "bin", "prog"), 300_000)
+	os.WriteFile(filepath.Join(tree, "etc", "version"), []byte("v1\n"), 0o644)
+	commit = strings.TrimSpace(run(t, "ostree", "--repo="+repo, "commit", "--branch=main",
+		"--generate-sizes", "--owner-uid=0", "--owner-gid=0", "--tree=dir="+tree))
+	return repo, "main", commit
+}
+
+// TestRemotePullSizeFromMeta confirms that when the commit carries ostree.sizes
+// metadata, RemotePullSize uses it (a single fetch), matches the on-disk object
+// totals, and also reports the uncompressed size.
+func TestRemotePullSizeFromMeta(t *testing.T) {
+	requireOstree(t)
+	repo, _, commit := makeSizesRepo(t)
+	srv := httptest.NewServer(http.FileServer(http.Dir(repo)))
+	defer srv.Close()
+
+	wantContent, wantMeta, nContent, nMeta := sumRepoObjectBytes(t, repo)
+
+	ps, err := RemotePullSize(context.Background(), RemoteConfig{BaseURL: srv.URL}, commit, nil)
+	if err != nil {
+		t.Fatalf("RemotePullSize: %v", err)
+	}
+	if !ps.FromSizesMeta {
+		t.Fatalf("expected FromSizesMeta=true when ostree.sizes present")
+	}
+	if ps.Compressed != wantContent+wantMeta {
+		t.Errorf("compressed = %d, want %d (content %d + meta %d)", ps.Compressed, wantContent+wantMeta, wantContent,
+			wantMeta)
+	}
+	if ps.ContentObjects != nContent {
+		t.Errorf("content objects = %d, want %d", ps.ContentObjects, nContent)
+	}
+	if ps.MetaObjects != nMeta {
+		t.Errorf("meta objects = %d, want %d", ps.MetaObjects, nMeta)
+	}
+	if ps.Uncompressed == 0 {
+		t.Errorf("expected a non-zero uncompressed size from ostree.sizes, got 0 (compressed %d)", ps.Compressed)
+	}
+}
+
+// TestRemotePullSizeMetaMatchesObjects cross-checks the ostree.sizes fast path
+// against the actual on-disk object totals for the same repo.
+func TestRemotePullSizeMetaMatchesObjects(t *testing.T) {
+	requireOstree(t)
+	repo, _, commit := makeSizesRepo(t)
+	srv := httptest.NewServer(http.FileServer(http.Dir(repo)))
+	defer srv.Close()
+
+	fromMeta, err := RemotePullSize(context.Background(), RemoteConfig{BaseURL: srv.URL}, commit, nil)
+	if err != nil {
+		t.Fatalf("RemotePullSize: %v", err)
+	}
+	if !fromMeta.FromSizesMeta {
+		t.Fatalf("expected FromSizesMeta=true")
+	}
+	wantContent, wantMeta, _, _ := sumRepoObjectBytes(t, repo)
+	if fromMeta.Compressed != wantContent+wantMeta {
+		t.Errorf("sizes-meta compressed = %d, want %d", fromMeta.Compressed, wantContent+wantMeta)
+	}
+}
+
+// TestRemotePullSizeViaRef confirms a ref is resolved to its commit before
+// sizing, and file:// transport works too.
+func TestRemotePullSizeViaRef(t *testing.T) {
+	requireOstree(t)
+	repo, ref, commit := makeSizesRepo(t)
+
+	got, err := ResolveRemoteRef(context.Background(), RemoteConfig{BaseURL: "file://" + repo}, ref)
+	if err != nil {
+		t.Fatalf("ResolveRemoteRef: %v", err)
+	}
+	if got != commit {
+		t.Fatalf("ResolveRemoteRef(%s) = %s, want %s", ref, got, commit)
+	}
+
+	ps, err := RemotePullSize(context.Background(), RemoteConfig{BaseURL: "file://" + repo}, got, nil)
+	if err != nil {
+		t.Fatalf("RemotePullSize (file): %v", err)
+	}
+	wantContent, wantMeta, _, _ := sumRepoObjectBytes(t, repo)
+	if ps.Compressed != wantContent+wantMeta {
+		t.Errorf("total size = %d, want %d", ps.Compressed, wantContent+wantMeta)
+	}
+}
+
+// TestRemotePullSizeLocalRepoSizesMeta verifies that objects already present in
+// localRepo are excluded from the ostree.sizes estimate. After a full pull the
+// estimate must drop to zero.
+func TestRemotePullSizeLocalRepoSizesMeta(t *testing.T) {
+	requireOstree(t)
+	srcRepo, _, commit := makeSizesRepo(t)
+	srv := httptest.NewServer(http.FileServer(http.Dir(srcRepo)))
+	defer srv.Close()
+	rc := RemoteConfig{BaseURL: srv.URL}
+
+	// Pull into a local bare-user repo.
+	dest := t.TempDir()
+	localRepo := OpenRepo(dest)
+	if _, err := localRepo.Pull(context.Background(), PullOptions{Remote: rc, Commit: commit}); err != nil {
+		t.Fatalf("pull: %v", err)
+	}
+
+	// Fast path with all objects local: estimate must be zero.
+	ps, err := RemotePullSize(context.Background(), rc, commit, localRepo)
+	if err != nil {
+		t.Fatalf("RemotePullSize: %v", err)
+	}
+	if !ps.FromSizesMeta {
+		t.Fatalf("expected FromSizesMeta=true")
+	}
+	if ps.Compressed != 0 {
+		t.Errorf("after full pull (sizes-meta path), size = %d, want 0", ps.Compressed)
+	}
+}

--- a/pkg/ostree/pull_test.go
+++ b/pkg/ostree/pull_test.go
@@ -1,0 +1,373 @@
+//go:build linux
+
+package ostree
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// zeroTime disables Last-Modified handling in http.ServeContent.
+var zeroTime = time.Time{}
+
+// TestPullEndToEnd pulls a commit from an archive repo served over HTTP into a
+// fresh bare-user repo, then validates it with `ostree fsck` and compares the
+// file listing against the source.
+func TestPullEndToEnd(t *testing.T) {
+	requireOstree(t)
+	srcRepo, ref, commit := makeContentRepo(t)
+	srv := httptest.NewServer(http.FileServer(http.Dir(srcRepo)))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "dest")
+	r := OpenRepo(dest)
+	res, err := r.Pull(context.Background(), PullOptions{
+		Remote: RemoteConfig{BaseURL: srv.URL},
+		Ref:    ref,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Commit != commit {
+		t.Fatalf("pulled commit %s want %s", res.Commit, commit)
+	}
+	if res.ContentFetched == 0 || res.MetaFetched == 0 {
+		t.Fatalf("expected objects fetched, got %+v", res)
+	}
+
+	// fsck must pass on the destination bare-user repo.
+	out := run(t, "ostree", "--repo="+dest, "fsck")
+	if !strings.Contains(out, "no errors found") {
+		t.Errorf("fsck output unexpected:\n%s", out)
+	}
+	// The pulled ref resolves to the same commit.
+	got, err := r.ResolveRef(ref)
+	if err != nil || got != commit {
+		t.Fatalf("ResolveRef=%q,%v want %s", got, err, commit)
+	}
+	// Listings match.
+	srcLs := run(t, "ostree", "--repo="+srcRepo, "ls", "-R", commit)
+	dstLs := run(t, "ostree", "--repo="+dest, "ls", "-R", commit)
+	if srcLs != dstLs {
+		t.Errorf("listings differ:\n--- src ---\n%s\n--- dst ---\n%s", srcLs, dstLs)
+	}
+}
+
+// TestPullObjectLevelResume verifies a re-run after losing the ref + partial
+// marker (but keeping objects) re-fetches nothing.
+func TestPullObjectLevelResume(t *testing.T) {
+	requireOstree(t)
+	srcRepo, ref, _ := makeContentRepo(t)
+	srv := httptest.NewServer(http.FileServer(http.Dir(srcRepo)))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "dest")
+	r := OpenRepo(dest)
+	opts := PullOptions{Remote: RemoteConfig{BaseURL: srv.URL}, Ref: ref}
+	if _, err := r.Pull(context.Background(), opts); err != nil {
+		t.Fatal(err)
+	}
+	// Second run: everything present -> all skipped, nothing fetched.
+	res, err := r.Pull(context.Background(), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.ContentFetched != 0 || res.MetaFetched != 0 {
+		t.Errorf("re-run fetched objects, expected all skipped: %+v", res)
+	}
+	if res.ObjectsSkipped == 0 {
+		t.Errorf("expected skips on re-run, got %+v", res)
+	}
+}
+
+// flakyServer serves files but, for the first request whose path contains
+// trigger, cuts the response off after maxBytes bytes (and does NOT honor Range
+// on that first hit) to simulate a dropped connection mid-object.
+type flakyServer struct {
+	root     string
+	trigger  string
+	maxBytes int
+
+	mu      sync.Mutex
+	tripped bool
+	ranges  []string // recorded Range headers for the trigger path
+}
+
+func (s *flakyServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rel := strings.TrimPrefix(r.URL.Path, "/")
+	full := filepath.Join(s.root, filepath.FromSlash(rel))
+	data, err := os.ReadFile(full)
+	if err != nil {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+
+	isTrigger := strings.Contains(rel, s.trigger)
+	if isTrigger {
+		s.mu.Lock()
+		s.ranges = append(s.ranges, r.Header.Get("Range"))
+		first := !s.tripped
+		s.tripped = true
+		s.mu.Unlock()
+		if first {
+			// Truncate: send a short prefix then stop (connection closes when
+			// the handler returns without writing the rest).
+			w.Header().Set("Content-Length", itoa(len(data)))
+			w.WriteHeader(http.StatusOK)
+			n := s.maxBytes
+			if n > len(data) {
+				n = len(data)
+			}
+			w.Write(data[:n])
+			if fl, ok := w.(http.Flusher); ok {
+				fl.Flush()
+			}
+			// Hijack and close to force the client to see a short read.
+			if hj, ok := w.(http.Hijacker); ok {
+				if conn, _, err := hj.Hijack(); err == nil {
+					conn.Close()
+				}
+			}
+			return
+		}
+	}
+	// Normal path (and all retries): honor Range via ServeContent.
+	http.ServeContent(w, r, filepath.Base(full), zeroTime, strings.NewReader(string(data)))
+}
+
+// TestPullByteLevelResume is the headline test: an object download is cut off
+// mid-stream; the retry must resume via a Range request rather than restart.
+func TestPullByteLevelResume(t *testing.T) {
+	requireOstree(t)
+	srcRepo, ref, commit := makeContentRepo(t)
+
+	// The large object is the random 1.5MB "prog" file; target its .filez.
+	r0 := OpenRepo(srcRepo)
+	bigCsum := largestFileObject(t, r0, commit)
+	fs := &flakyServer{root: srcRepo, trigger: bigCsum[2:] + ".filez", maxBytes: 4096}
+	srv := httptest.NewServer(fs)
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "dest")
+	r := OpenRepo(dest)
+	opts := PullOptions{Remote: RemoteConfig{BaseURL: srv.URL}, Ref: ref, Concurrency: 1}
+
+	// First attempt: should fail on the truncated object.
+	_, err := r.Pull(context.Background(), opts)
+	if err == nil {
+		t.Fatal("expected first pull to fail on truncated object")
+	}
+	// A .part sidecar should remain with the partial bytes.
+	part := filepath.Join(dest, "tmp", bigCsum+".filez.part")
+	fi, perr := os.Stat(part)
+	if perr != nil {
+		t.Fatalf("expected partial sidecar %s: %v", part, perr)
+	}
+	if fi.Size() == 0 {
+		t.Fatal("partial sidecar is empty")
+	}
+
+	// Second attempt against the now-healthy server: must succeed and must have
+	// issued a Range request for the resumed object.
+	res, err := r.Pull(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("resume pull failed: %v", err)
+	}
+	fs.mu.Lock()
+	ranges := append([]string(nil), fs.ranges...)
+	fs.mu.Unlock()
+	sawRange := false
+	for _, rg := range ranges {
+		if strings.HasPrefix(rg, "bytes=") && rg != "bytes=0-" {
+			sawRange = true
+		}
+	}
+	if !sawRange {
+		t.Errorf("expected a resume Range request, recorded ranges: %v", ranges)
+	}
+	if res.Commit != commit {
+		t.Fatalf("commit %s want %s", res.Commit, commit)
+	}
+	out := run(t, "ostree", "--repo="+dest, "fsck")
+	if !strings.Contains(out, "no errors found") {
+		t.Errorf("fsck after resume failed:\n%s", out)
+	}
+}
+
+// TestPullRangeIgnoredFallback ensures correctness when the server ignores Range
+// and always returns 200 (the stdlib FileServer with a pre-seeded .part).
+func TestPullRangeIgnoredFallback(t *testing.T) {
+	requireOstree(t)
+	srcRepo, ref, commit := makeContentRepo(t)
+	// A plain handler that always returns the whole file with 200, never 206.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rel := strings.TrimPrefix(r.URL.Path, "/")
+		data, err := os.ReadFile(filepath.Join(srcRepo, filepath.FromSlash(rel)))
+		if err != nil {
+			http.Error(w, "nf", http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK) // ignore any Range
+		w.Write(data)
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "dest")
+	r := OpenRepo(dest)
+	// Pre-seed a bogus partial for the big object to exercise the truncate path.
+	bigCsum := largestFileObject(t, OpenRepo(srcRepo), commit)
+	os.MkdirAll(filepath.Join(dest, "tmp"), 0o755)
+	os.WriteFile(filepath.Join(dest, "tmp", bigCsum+".filez.part"), []byte("garbage"), 0o644)
+
+	res, err := r.Pull(context.Background(), PullOptions{Remote: RemoteConfig{BaseURL: srv.URL}, Ref: ref})
+	if err != nil {
+		t.Fatalf("pull with Range-ignoring server failed: %v", err)
+	}
+	if res.Commit != commit {
+		t.Fatalf("commit mismatch")
+	}
+	out := run(t, "ostree", "--repo="+dest, "fsck")
+	if !strings.Contains(out, "no errors found") {
+		t.Errorf("fsck failed:\n%s", out)
+	}
+}
+
+// largestFileObject returns the checksum of the largest regular-file content
+// object reachable from the commit (the random blob).
+func largestFileObject(t *testing.T, r *Repo, commit string) string {
+	t.Helper()
+	c, err := r.ReadCommit(commit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var best string
+	var bestSize int64
+	var walk func(tree string)
+	walk = func(tree string) {
+		entries, err := r.ReadDirTree(tree)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, e := range entries {
+			if e.IsDir {
+				walk(e.Checksum)
+				continue
+			}
+			fi, err := os.Stat(r.objectPath(e.Checksum, "filez"))
+			if err == nil && fi.Size() > bestSize {
+				bestSize = fi.Size()
+				best = e.Checksum
+			}
+		}
+	}
+	walk(c.RootDirTree)
+	if best == "" {
+		t.Fatal("no file object found")
+	}
+	return best
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}
+
+// failOneServer serves an archive repo but returns HTTP 500 for every request
+// to one chosen content object, so its fetch fails permanently.
+type failOneServer struct {
+	root string
+	fail string // substring of the path that should hard-fail
+}
+
+func (s *failOneServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rel := strings.TrimPrefix(r.URL.Path, "/")
+	if s.fail != "" && strings.Contains(rel, s.fail) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+		return
+	}
+	full := filepath.Join(s.root, filepath.FromSlash(rel))
+	data, err := os.ReadFile(full)
+	if err != nil {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	http.ServeContent(w, r, filepath.Base(full), zeroTime, strings.NewReader(string(data)))
+}
+
+// TestPullContentFetchErrorNoDeadlock is a regression test for a semaphore
+// acquire/release imbalance in fetchContentObjects: when one content fetch
+// failed and cancelled the context, the acquire loop could take the ctx.Done()
+// branch yet still launch a goroutine that released a slot it never acquired,
+// deadlocking wg.Wait() ("all goroutines are asleep - deadlock"). A failing
+// object must make Pull return the error promptly instead of hanging.
+func TestPullContentFetchErrorNoDeadlock(t *testing.T) {
+	requireOstree(t)
+
+	// Build a repo with many small content objects so the fetch runs well past
+	// the concurrency limit while one object hard-fails mid-batch.
+	dir := t.TempDir()
+	srcRepo := filepath.Join(dir, "repo")
+	tree := filepath.Join(dir, "tree")
+	if err := os.MkdirAll(filepath.Join(tree, "files"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	run(t, "ostree", "--repo="+srcRepo, "init", "--mode=archive")
+	for i := 0; i < 60; i++ {
+		writeRandom(t, filepath.Join(tree, "files", "f"+itoa(i)), 4096)
+	}
+	commit := strings.TrimSpace(run(t, "ostree", "--repo="+srcRepo, "commit", "--branch=main",
+		"--owner-uid=0", "--owner-gid=0", "--tree=dir="+tree))
+
+	// Pick any content object's .filez to fail on.
+	var failCsum string
+	filepath.Walk(filepath.Join(srcRepo, "objects"), func(p string, fi os.FileInfo, err error) error {
+		if err == nil && !fi.IsDir() && strings.HasSuffix(p, ".filez") && failCsum == "" {
+			failCsum = filepath.Base(p)
+		}
+		return nil
+	})
+	if failCsum == "" {
+		t.Fatal("no .filez content object found in repo")
+	}
+
+	srv := httptest.NewServer(&failOneServer{root: srcRepo, fail: failCsum})
+	defer srv.Close()
+
+	dest := t.TempDir()
+	done := make(chan error, 1)
+	go func() {
+		_, err := OpenRepo(dest).Pull(context.Background(), PullOptions{
+			Remote: RemoteConfig{BaseURL: srv.URL}, Commit: commit, Concurrency: 4,
+		})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected a fetch error, got nil")
+		}
+	case <-time.After(30 * time.Second):
+		// Dump goroutines to make a re-introduced deadlock obvious.
+		buf := make([]byte, 1<<16)
+		n := runtime.Stack(buf, true)
+		t.Fatalf("Pull did not return within 30s (deadlock?):\n%s", buf[:n])
+	}
+}

--- a/pkg/ostree/repo.go
+++ b/pkg/ostree/repo.go
@@ -1,0 +1,103 @@
+// Package ostree is a pure-Go reader of the ostree on-disk repository format.
+//
+// It links no libostree and shells out to no `ostree` binary: it reads the
+// repository's files directly and decodes their GVariant contents (see
+// pkg/gvariant). Its first feature is pre-flight storage estimation for static
+// -delta updates (reading the superblock the same way `ostree static-delta
+// show` does); the repo handle, ref resolver and commit/dirtree readers it also
+// provides are the foundation for later object-fetching work.
+package ostree
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// Repo is a handle to a local ostree repository identified by its filesystem
+// path (the directory containing "config", "objects", "refs", "deltas", ...).
+type Repo struct {
+	path     string
+	mode     string    // cached core.mode from config; resolved once via modeOnce
+	modeOnce sync.Once // guards the lazy read of mode in repoMode()
+	initMode string    // mode to use when initializing a fresh repo (default bare-user)
+}
+
+// OpenRepo returns a handle for the repo at path. It does not validate eagerly;
+// errors surface when an operation actually touches the repository.
+func OpenRepo(path string) *Repo { return &Repo{path: path} }
+
+// WithMode sets the on-disk mode used when initializing a fresh repo (see
+// ensureRepo). It has no effect on an already-initialized repo, whose mode is
+// read from its config. Valid values: "bare-user", "bare-user-only".
+func (r *Repo) WithMode(mode string) *Repo {
+	if mode != "" {
+		r.initMode = mode
+	}
+	return r
+}
+
+// Path returns the repository path.
+func (r *Repo) Path() string { return r.path }
+
+// Repo modes this package can write into.
+const (
+	modeBareUser     = "bare-user"
+	modeBareUserOnly = "bare-user-only"
+)
+
+// reModeLine matches a `mode=<value>` line in the repo config's [core] section.
+var reModeLine = regexp.MustCompile(`(?m)^\s*mode\s*=\s*(\S+)\s*$`)
+
+// repoMode returns the repository's core.mode (e.g. "bare-user-only"), read from
+// <repo>/config and cached. It defaults to bare-user when the config is missing
+// or has no mode line (matching what ensureRepo creates). Safe for concurrent
+// use: the read happens exactly once.
+func (r *Repo) repoMode() string {
+	r.modeOnce.Do(func() {
+		r.mode = modeBareUser
+		if b, err := os.ReadFile(filepath.Join(r.path, "config")); err == nil {
+			if m := reModeLine.FindSubmatch(b); m != nil {
+				r.mode = string(m[1])
+			}
+		}
+	})
+	return r.mode
+}
+
+var hexCsumRe = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+// ResolveRef turns a ref into a 64-hex commit checksum. If ref already looks
+// like a checksum it is returned unchanged; otherwise the ref file is read from
+// refs/heads, then refs/remotes (matching the common ostree lookup order).
+func (r *Repo) ResolveRef(ref string) (string, error) {
+	if hexCsumRe.MatchString(ref) {
+		return ref, nil
+	}
+	candidates := []string{
+		filepath.Join(r.path, "refs", "heads", filepath.FromSlash(ref)),
+		filepath.Join(r.path, "refs", "remotes", filepath.FromSlash(ref)),
+	}
+	for _, p := range candidates {
+		b, err := os.ReadFile(p)
+		if err == nil {
+			csum := strings.TrimSpace(string(b))
+			if !hexCsumRe.MatchString(csum) {
+				return "", fmt.Errorf("ref %q: %q is not a commit checksum", ref, csum)
+			}
+			return csum, nil
+		}
+		if !os.IsNotExist(err) {
+			return "", fmt.Errorf("ref %q: %w", ref, err)
+		}
+	}
+	return "", fmt.Errorf("ref %q not found", ref)
+}
+
+// objectPath returns the loose-object path objects/<csum[0:2]>/<csum[2:]>.<ext>.
+func (r *Repo) objectPath(csum, ext string) string {
+	return filepath.Join(r.path, "objects", csum[:2], csum[2:]+"."+ext)
+}

--- a/pkg/ostree/repo_test.go
+++ b/pkg/ostree/repo_test.go
@@ -1,0 +1,56 @@
+//go:build linux
+
+package ostree
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestResolveAndReadCommit resolves the test ref to its commit and decodes the
+// commit + root dirtree purely in Go, cross-checking against the ostree CLI.
+func TestResolveAndReadCommit(t *testing.T) {
+	requireOstree(t)
+	repo, _, to := makeDeltaRepo(t)
+	r := OpenRepo(repo)
+
+	csum, err := r.ResolveRef("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if csum != to {
+		t.Fatalf("ResolveRef(test): got %s want %s", csum, to)
+	}
+
+	c, err := r.ReadCommit(csum)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(c.RootDirTree) != 64 {
+		t.Fatalf("root dirtree checksum looks wrong: %q", c.RootDirTree)
+	}
+
+	// Walk the root dirtree; it must contain the "usr" and "etc" subdirs we
+	// committed.
+	entries, err := r.ReadDirTree(c.RootDirTree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dirs := map[string]bool{}
+	for _, e := range entries {
+		if e.IsDir {
+			dirs[e.Name] = true
+		}
+	}
+	for _, want := range []string{"usr", "etc"} {
+		if !dirs[want] {
+			t.Errorf("root dirtree missing subdir %q (got %v)", want, dirs)
+		}
+	}
+
+	// Cross-check against `ostree ls`: the root listing should mention usr/etc.
+	ls := run(t, "ostree", "--repo="+repo, "ls", csum)
+	if !strings.Contains(ls, "/usr") || !strings.Contains(ls, "/etc") {
+		t.Errorf("ostree ls disagrees:\n%s", ls)
+	}
+}

--- a/pkg/ostree/statfs.go
+++ b/pkg/ostree/statfs.go
@@ -1,0 +1,76 @@
+//go:build linux
+
+package ostree
+
+import (
+	"fmt"
+	"syscall"
+)
+
+// UsageInfo mirrors the shape used by composeapp (pkg/compose/statfs.go) so the
+// figures line up with the rest of the Foundries tooling.
+type UsageInfo struct {
+	Path       string  `json:"path"`
+	SizeB      uint64  `json:"size_b"`
+	Free       uint64  `json:"free"`
+	FreeP      float32 `json:"free_p"`
+	Reserved   uint64  `json:"reserved"`
+	ReservedP  float32 `json:"reserved_p"`
+	Available  uint64  `json:"available"`
+	AvailableP float32 `json:"available_p"`
+	Required   uint64  `json:"required"`
+	RequiredP  float32 `json:"required_p"`
+}
+
+var binaryAbbrs = []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"}
+
+// FormatBytes renders a byte count using binary (1024) units, e.g. "3.001 MiB".
+func FormatBytes(size uint64) string {
+	v := float64(size)
+	i := 0
+	for v >= 1024 && i < len(binaryAbbrs)-1 {
+		v /= 1024
+		i++
+	}
+	if i == 0 {
+		return fmt.Sprintf("%d %s", size, binaryAbbrs[i])
+	}
+	return fmt.Sprintf("%.4g %s", v, binaryAbbrs[i])
+}
+
+// GetUsageInfo reports filesystem usage for path against a watermark that bounds
+// how much storage may be consumed. The watermark is a percentage of total size
+// when watermarkInBytes is false, or an absolute amount of free space to keep
+// reserved (in bytes) when watermarkInBytes is true. This matches composeapp's
+// GetUsageInfo semantics.
+func GetUsageInfo(path string, required uint64, watermark uint64, watermarkInBytes bool) (*UsageInfo, error) {
+	var st syscall.Statfs_t
+	if err := syscall.Statfs(path, &st); err != nil {
+		return nil, err
+	}
+	bsize := uint64(st.Bsize)
+	ui := UsageInfo{
+		Path:     path,
+		SizeB:    bsize * st.Blocks,
+		Free:     st.Bfree * bsize,
+		Required: required,
+	}
+	if ui.SizeB > 0 {
+		ui.FreeP = (float32(ui.Free) / float32(ui.SizeB)) * 100.0
+		ui.RequiredP = (float32(ui.Required) / float32(ui.SizeB)) * 100.0
+	}
+	if watermarkInBytes {
+		ui.Reserved = watermark
+		if ui.SizeB > 0 {
+			ui.ReservedP = (float32(ui.Reserved) / float32(ui.SizeB)) * 100.0
+		}
+	} else {
+		ui.Reserved = uint64((float64(100-watermark) / 100.0) * float64(ui.SizeB))
+		ui.ReservedP = float32(100 - watermark)
+	}
+	if ui.Free > ui.Reserved {
+		ui.Available = ui.Free - ui.Reserved
+		ui.AvailableP = ui.FreeP - ui.ReservedP
+	}
+	return &ui, nil
+}

--- a/pkg/ostree/update_size.go
+++ b/pkg/ostree/update_size.go
@@ -1,0 +1,73 @@
+//go:build linux
+
+package ostree
+
+import (
+	"context"
+	"errors"
+)
+
+// SizeMethod identifies which source produced an UpdateSize, in increasing order
+// of cost.
+type SizeMethod string
+
+const (
+	// SizeFromDelta: read from the remote static-delta superblock (one fetch).
+	SizeFromDelta SizeMethod = "delta"
+	// SizeFromSizesMeta: read from the commit's ostree.sizes metadata (one fetch).
+	SizeFromSizesMeta SizeMethod = "sizes-meta"
+)
+
+// ErrSizeUnavailable reports that the update size could not be determined from a
+// cheap source: neither a published static delta nor the commit's ostree.sizes
+// metadata is available. It lets a caller distinguish "no efficient estimate
+// exists" from a real error, and decide for itself whether to proceed without
+// one.
+var ErrSizeUnavailable = errors.New("update size unavailable: no static delta and no ostree.sizes metadata")
+
+// UpdateSize is the estimated storage an update to `to` needs.
+type UpdateSize struct {
+	// Compressed is the download size in bytes (what crosses the network).
+	Compressed uint64 `json:"compressed"`
+	// Uncompressed is the on-disk size in bytes.
+	Uncompressed uint64 `json:"uncompressed"`
+	// Method reports which source produced the figures.
+	Method SizeMethod `json:"method"`
+}
+
+// RemoteUpdateSize estimates the storage a from->to update needs, trying the
+// cheapest accurate source first:
+//
+//  1. If from is set and the remote publishes a from->to static delta, read the
+//     sizes from its superblock (one fetch). Both compressed and uncompressed.
+//  2. Else, if the `to` commit carries ostree.sizes metadata, read the sizes
+//     from the commit object (one fetch). Both compressed and uncompressed.
+//
+// When neither source is available, ErrSizeUnavailable is returned.
+//
+// localRepo, if non-nil, is used to subtract objects already present on disk so
+// the returned sizes reflect only what would actually be downloaded/written, not
+// a full fresh-pull total.
+//
+// This is the single entry point a caller should use to size an update; it makes
+// the delta/metadata decision internally.
+func RemoteUpdateSize(ctx context.Context, rc RemoteConfig, from, to string, localRepo *Repo) (UpdateSize, error) {
+	// 1. Static-delta superblock (cheapest) when a base commit is known.
+	if from != "" {
+		ds, err := RemoteDeltaSize(ctx, rc, from, to)
+		if err == nil {
+			return UpdateSize{Compressed: ds.Compressed, Uncompressed: ds.Uncompressed, Method: SizeFromDelta}, nil
+		}
+		if !errors.Is(err, ErrNoDelta) {
+			return UpdateSize{}, err
+		}
+		// No delta published for this pair: fall through to the ostree.sizes path.
+	}
+
+	// 2. Full-pull sizing from the commit's ostree.sizes metadata.
+	ps, err := RemotePullSize(ctx, rc, to, localRepo)
+	if err != nil {
+		return UpdateSize{}, err
+	}
+	return UpdateSize{Compressed: ps.Compressed, Uncompressed: ps.Uncompressed, Method: SizeFromSizesMeta}, nil
+}

--- a/pkg/ostree/update_size_test.go
+++ b/pkg/ostree/update_size_test.go
@@ -1,0 +1,96 @@
+//go:build linux
+
+package ostree
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestRemoteUpdateSizeDelta: when a from->to static delta is published, the
+// unified entry point uses it (Method=delta) and matches RemoteDeltaSize.
+func TestRemoteUpdateSizeDelta(t *testing.T) {
+	requireOstree(t)
+	repo, from, to := makeDeltaRepo(t)
+	srv := httptest.NewServer(http.FileServer(http.Dir(repo)))
+	defer srv.Close()
+
+	us, err := RemoteUpdateSize(context.Background(), RemoteConfig{BaseURL: srv.URL}, from, to, nil)
+	if err != nil {
+		t.Fatalf("RemoteUpdateSize: %v", err)
+	}
+	if us.Method != SizeFromDelta {
+		t.Fatalf("method = %q, want delta", us.Method)
+	}
+	want, err := RemoteDeltaSize(context.Background(), RemoteConfig{BaseURL: srv.URL}, from, to)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if us.Compressed != want.Compressed || us.Uncompressed != want.Uncompressed {
+		t.Errorf("update-size %+v != delta-size %+v", us, want)
+	}
+}
+
+// TestRemoteUpdateSizeNoDeltaFallsBackToSizesMeta: with no delta published but a
+// commit carrying ostree.sizes, it falls back to the metadata (Method=sizes-meta),
+// still yielding an uncompressed figure.
+func TestRemoteUpdateSizeNoDeltaFallsBackToSizesMeta(t *testing.T) {
+	requireOstree(t)
+	repo, _, to := makeSizesRepo(t)
+	srv := httptest.NewServer(http.FileServer(http.Dir(repo)))
+	defer srv.Close()
+
+	const absentFrom = "0000000000000000000000000000000000000000000000000000000000000000"
+	us, err := RemoteUpdateSize(context.Background(), RemoteConfig{BaseURL: srv.URL}, absentFrom, to, nil)
+	if err != nil {
+		t.Fatalf("RemoteUpdateSize: %v", err)
+	}
+	if us.Method != SizeFromSizesMeta {
+		t.Fatalf("method = %q, want sizes-meta", us.Method)
+	}
+	if us.Compressed == 0 || us.Uncompressed == 0 {
+		t.Errorf("expected non-zero compressed and uncompressed, got %+v", us)
+	}
+}
+
+// TestRemoteUpdateSizeUnavailable: no delta and no ostree.sizes -> the size
+// cannot be determined and ErrSizeUnavailable is returned.
+func TestRemoteUpdateSizeUnavailable(t *testing.T) {
+	requireOstree(t)
+	repo, _, to := makeContentRepoOpts(t, true) // no --generate-sizes
+	srv := httptest.NewServer(http.FileServer(http.Dir(repo)))
+	defer srv.Close()
+
+	_, err := RemoteUpdateSize(context.Background(), RemoteConfig{BaseURL: srv.URL}, "", to, nil)
+	if !errors.Is(err, ErrSizeUnavailable) {
+		t.Fatalf("expected ErrSizeUnavailable, got %v", err)
+	}
+}
+
+// TestRemoteUpdateSizeAlreadyUpToDate: when from==to and the local repo has all
+// objects, the estimate must be 0 — the device is already on the target commit.
+func TestRemoteUpdateSizeAlreadyUpToDate(t *testing.T) {
+	requireOstree(t)
+	srcRepo, _, commit := makeSizesRepo(t)
+	srv := httptest.NewServer(http.FileServer(http.Dir(srcRepo)))
+	defer srv.Close()
+	rc := RemoteConfig{BaseURL: srv.URL}
+
+	dest := t.TempDir()
+	localRepo := OpenRepo(dest)
+	if _, err := localRepo.Pull(context.Background(), PullOptions{Remote: rc, Commit: commit}); err != nil {
+		t.Fatalf("pull: %v", err)
+	}
+
+	// from == to: no delta will exist, falls to sizes-meta path, all objects local.
+	us, err := RemoteUpdateSize(context.Background(), rc, commit, commit, localRepo)
+	if err != nil {
+		t.Fatalf("RemoteUpdateSize: %v", err)
+	}
+	if us.Compressed != 0 {
+		t.Errorf("already up-to-date: compressed = %d, want 0", us.Compressed)
+	}
+}

--- a/pkg/varint/varint.go
+++ b/pkg/varint/varint.go
@@ -1,0 +1,32 @@
+// Package varint decodes the unsigned LEB128 varints ostree uses to encode
+// static-delta operation operands (libostree _ostree_read_varuint64). It is the
+// same wire form as encoding/binary.Uvarint, but exposed here with an explicit
+// 10-byte cap and an io-free byte-slice API matching the delta processor.
+package varint
+
+import "errors"
+
+// ErrOverflow is returned when a varint does not terminate within 10 bytes.
+var ErrOverflow = errors.New("varint: value overflows 64 bits")
+
+// ErrTruncated is returned when the buffer ends mid-varint.
+var ErrTruncated = errors.New("varint: truncated")
+
+// Uvarint decodes an unsigned LEB128 varint from buf, returning the value and
+// the number of bytes consumed.
+func Uvarint(buf []byte) (uint64, int, error) {
+	var result uint64
+	for i := 0; ; i++ {
+		if i == 10 {
+			return 0, 0, ErrOverflow
+		}
+		if i >= len(buf) {
+			return 0, 0, ErrTruncated
+		}
+		b := buf[i]
+		result |= uint64(b&0x7F) << (7 * i)
+		if b&0x80 == 0 {
+			return result, i + 1, nil
+		}
+	}
+}

--- a/pkg/varint/varint_test.go
+++ b/pkg/varint/varint_test.go
@@ -1,0 +1,42 @@
+package varint
+
+import "testing"
+
+func TestUvarint(t *testing.T) {
+	cases := []struct {
+		bytes []byte
+		val   uint64
+		n     int
+	}{
+		{[]byte{0x00}, 0, 1},
+		{[]byte{0x01}, 1, 1},
+		{[]byte{0x7f}, 127, 1},
+		{[]byte{0x80, 0x01}, 128, 2},
+		{[]byte{0xac, 0x02}, 300, 2},
+		{[]byte{0xff, 0xff, 0xff, 0xff, 0x0f}, 0xFFFFFFFF, 5},
+	}
+	for _, c := range cases {
+		v, n, err := Uvarint(c.bytes)
+		if err != nil {
+			t.Errorf("%x: unexpected error %v", c.bytes, err)
+			continue
+		}
+		if v != c.val || n != c.n {
+			t.Errorf("%x: got (%d,%d), want (%d,%d)", c.bytes, v, n, c.val, c.n)
+		}
+	}
+}
+
+func TestUvarintErrors(t *testing.T) {
+	if _, _, err := Uvarint(nil); err != ErrTruncated {
+		t.Errorf("empty: got %v, want ErrTruncated", err)
+	}
+	if _, _, err := Uvarint([]byte{0x80, 0x80}); err != ErrTruncated {
+		t.Errorf("unterminated: got %v, want ErrTruncated", err)
+	}
+	// 11 continuation bytes -> overflow.
+	big := []byte{0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01}
+	if _, _, err := Uvarint(big); err != ErrOverflow {
+		t.Errorf("overflow: got %v, want ErrOverflow", err)
+	}
+}


### PR DESCRIPTION
Add fiopull command, a pure go implementation that provides 2 subcommands:
- update-size: estimates the amount of bytes required for the update (both wire and storage)
- pull: pulls a commit (delta-aware, resumable) into a local repo
